### PR TITLE
feat(feature-flags): add discussion_thread_summarizer flag

### DIFF
--- a/config/feature_flags/discussion_thread_summarizer.yml
+++ b/config/feature_flags/discussion_thread_summarizer.yml
@@ -1,0 +1,19 @@
+---
+discussion_thread_summarizer:
+  state: allowed
+  root_opt_in: true
+  applies_to: Course
+  display_name: Discussion Thread Summarizer
+  description: >-
+    Summarize discussion threads using AI, surfacing main themes,
+    dominant viewpoints, and open questions. Disabled by default;
+    account admins must enable before courses can opt in.
+
+discussion_thread_summarizer_with_cedar:
+  state: hidden
+  applies_to: RootAccount
+  shadow: true
+  display_name: Discussion Thread Summarizer with Cedar
+  description: >-
+    Routes Discussion Thread Summarizer requests through Cedar
+    instead of direct model calls.


### PR DESCRIPTION
Declare the `discussion_thread_summarizer` feature flag and its Cedar companion shadow flag in `config/feature_flags/`.

Closes #1

## Summary

Adds `config/feature_flags/discussion_thread_summarizer.yml` mirroring the established `discussion_summary.yml` pattern. The primary flag defaults to off on upgrade (`state: allowed`, `root_opt_in: true`, `applies_to: Course`); account admins must enable it before any course can opt in. The companion shadow flag (`discussion_thread_summarizer_with_cedar`, `state: hidden`, `applies_to: RootAccount`, `shadow: true`) gates backend provider selection.

## Source of truth

- **Functional requirement:** FR-4 — Honor account- and course-level feature toggles
- **Milestone:** M1 — Foundations
- **Issue:** #1 — [M1] Declare discussion_thread_summarizer feature flag
- **Precedent file:** `config/feature_flags/discussion_summary.yml` (lines 2–13)

## Verification

- YAML syntax validated via `python3 -c "import yaml; yaml.safe_load(open(...))"` — passes
- YAML syntax validated via `docker compose run --rm web ruby -ryaml -e "YAML.load_file(...)"` — passes (`Keys: discussion_thread_summarizer, discussion_thread_summarizer_with_cedar`)
- Diff reviewed: one new file, 19 lines, no unrelated edits, no secrets, no commented-out code
- File path `config/feature_flags/discussion_thread_summarizer.yml` matches §4.4 codebase evidence
- Acceptance criteria met:
  - Flag `state: allowed` + `root_opt_in: true` → resolves false on fresh upgrade
  - `applies_to: Course` → account-then-course inheritance
  - Companion shadow flag declared with `state: hidden`, `applies_to: RootAccount`, `shadow: true`

## Scope

This PR intentionally does not include:
- Any controller, model, or UI wiring (M2+ work)
- Tests beyond YAML syntax (no Ruby runtime feature-flag behavior is introduced here; the flag framework's own tests cover inheritance)
- Any changes to existing files