### PR TITLE
feat(feature-flags): wire toggle UI plumbing for discussion_thread_summarizer

### DIFF
--- a/app/controllers/discussion_topics_controller.rb
+++ b/app/controllers/discussion_topics_controller.rb
@@ -907,6 +907,7 @@ class DiscussionTopicsController < ApplicationController
              user_can_access_insights: @topic.user_can_access_insights?(@current_user),
              discussion_pin_post: @context.feature_enabled?(:discussion_pin_post),
              discussion_summary_enabled: participant.nil? ? @topic.summary_enabled : participant.summary_enabled,
+             discussion_thread_summarizer_enabled: @context.is_a?(Course) && @context.feature_enabled?(:discussion_thread_summarizer),
              should_show_deeply_nested_alert: @current_user&.should_show_deeply_nested_alert?,
              # although there is a permissions object in DiscussionEntry type, it's only accessible if a discussion entry
              # is being replied to. We need this env var so that replying to the topic can use this

--- a/config/feature_flags/discussion_thread_summarizer.yml
+++ b/config/feature_flags/discussion_thread_summarizer.yml
@@ -8,6 +8,11 @@ discussion_thread_summarizer:
     Summarize discussion threads using AI, surfacing main themes,
     dominant viewpoints, and open questions. Disabled by default;
     account admins must enable before courses can opt in.
+  environments:
+    development:
+      state: allowed_on
+    ci:
+      state: allowed_on
 
 discussion_thread_summarizer_with_cedar:
   state: hidden

--- a/spec/controllers/discussion_topics_controller_spec.rb
+++ b/spec/controllers/discussion_topics_controller_spec.rb
@@ -710,6 +710,26 @@ describe DiscussionTopicsController do
       expect(response.location).to eq course_discussion_topics_url @course
     end
 
+    context "discussion_thread_summarizer_enabled js_env" do
+      let(:topic) do
+        @course.discussion_topics.create!(user: @teacher, title: "Test topic", message: "Hello")
+      end
+
+      it "is true when the feature is enabled for the course" do
+        @course.enable_feature!(:discussion_thread_summarizer)
+        user_session(@teacher)
+        get "show", params: { course_id: @course.id, id: topic.id }
+        expect(assigns[:js_env][:discussion_thread_summarizer_enabled]).to be(true)
+      end
+
+      it "is false when the feature is disabled for the course" do
+        @course.disable_feature!(:discussion_thread_summarizer)
+        user_session(@teacher)
+        get "show", params: { course_id: @course.id, id: topic.id }
+        expect(assigns[:js_env][:discussion_thread_summarizer_enabled]).to be(false)
+      end
+    end
+
     context "js_env DISCUSSION_TOPIC PERMISSIONS CAN_SET_GROUP" do
       it "CAN_SET_GROUP is true when user is a teacher" do
         user_session(@teacher)


### PR DESCRIPTION
Wire the `discussion_thread_summarizer` feature flag into the account and course feature settings UI and propagate its resolved state to the frontend ENV.

Closes #2

## Source of truth
- Functional requirement: FR-4 — Honor account- and course-level feature toggles
- Milestone: M1 — Foundations

## Changes

**`config/feature_flags/discussion_thread_summarizer.yml`** — adds `environments` block so the flag defaults to `allowed_on` in `development` and `ci`, enabling local and CI testing without a manual admin toggle. The flag remains `state: allowed` (off by default) in production, requiring an account admin to enable it.

**`app/controllers/discussion_topics_controller.rb`** — adds `discussion_thread_summarizer_enabled` to the `js_env` hash in `show`. The value is `@context.is_a?(Course) && @context.feature_enabled?(:discussion_thread_summarizer)`, which mirrors the flag's `applies_to: Course` scope and returns `false` for group-discussion contexts (group discussions are explicitly out of scope per `implementation-research.md` §2). Downstream M4 and M5 components will gate rendering on this key.

**`spec/controllers/discussion_topics_controller_spec.rb`** — two examples in `describe "GET 'show'"` verify the on and off states.

## Verification
QA command: `bundle exec rspec spec/controllers/discussion_topics_controller_spec.rb --example "discussion_thread_summarizer_enabled" --format documentation`
Outcome: exit code 0, 2 examples, 0 failures.
Matching entry: `agents/tasks/feature-1/qa-lab-evidence.md` Cycle 2.

## Scope
This PR does not render a summary block or digest tab — those are M4 and M5 work. No new permission objects, no new routes, no migration. The feature flag toggle UI entry is automatic from the existing YAML (display_name, description, state, root_opt_in, applies_to) and requires no separate UI code.