### PR TITLE
test(feature-flags): integration tests for flag inheritance chain

### DIFF
--- a/spec/controllers/discussion_topics_controller_spec.rb
+++ b/spec/controllers/discussion_topics_controller_spec.rb
@@ -730,6 +730,56 @@ describe DiscussionTopicsController do
       end
     end
 
+    context "feature-flag inheritance chain" do
+      # TODO (M2/M3): when the summarization job lands, add an example asserting
+      # no job is enqueued and no model call attempted when the resolved state is off.
+
+      let(:topic) do
+        @course.discussion_topics.create!(
+          user: @teacher,
+          title: "Inheritance test topic",
+          message: "Testing account→course flag resolution"
+        )
+      end
+
+      before do
+        user_session(@teacher)
+        # Reset any account- or course-level flag so each example starts
+        # from a known baseline, independent of the ci: allowed_on default.
+        @course.root_account.reset_feature!(:discussion_thread_summarizer)
+        @course.reset_feature!(:discussion_thread_summarizer)
+      end
+
+      it "resolves to false when the account has not enabled the flag and the course has no override" do
+        @course.root_account.allow_feature!(:discussion_thread_summarizer)
+        get "show", params: { course_id: @course.id, id: topic.id }
+        expect(assigns[:js_env][:discussion_thread_summarizer_enabled]).to be(false)
+      end
+
+      it "resolves to true when the account is off but the course overrides to on" do
+        @course.root_account.allow_feature!(:discussion_thread_summarizer)
+        @course.enable_feature!(:discussion_thread_summarizer)
+        get "show", params: { course_id: @course.id, id: topic.id }
+        expect(assigns[:js_env][:discussion_thread_summarizer_enabled]).to be(true)
+      end
+
+      it "resolves to true when the account enables for all courses and the course has no override" do
+        # STATE_DEFAULT_ON ("allowed_on"): on by default, can_override? = true,
+        # so the course can still opt out. STATE_ON would lock the flag and
+        # prevent course-level override (can_override? = false).
+        @course.root_account.set_feature_flag!(:discussion_thread_summarizer, Feature::STATE_DEFAULT_ON)
+        get "show", params: { course_id: @course.id, id: topic.id }
+        expect(assigns[:js_env][:discussion_thread_summarizer_enabled]).to be(true)
+      end
+
+      it "resolves to false when the account enables but the course overrides to off" do
+        @course.root_account.set_feature_flag!(:discussion_thread_summarizer, Feature::STATE_DEFAULT_ON)
+        @course.disable_feature!(:discussion_thread_summarizer)
+        get "show", params: { course_id: @course.id, id: topic.id }
+        expect(assigns[:js_env][:discussion_thread_summarizer_enabled]).to be(false)
+      end
+    end
+
     context "js_env DISCUSSION_TOPIC PERMISSIONS CAN_SET_GROUP" do
       it "CAN_SET_GROUP is true when user is a teacher" do
         user_session(@teacher)


### PR DESCRIPTION
## Summary

Integration tests for the `discussion_thread_summarizer` feature-flag inheritance chain (account default → course override). Covers all four account/course on/off combinations defined in issue #5, plus a TODO marker for the M2/M3 job-enqueue assertion.

Closes #5

## Source of truth

- Functional requirement: FR-4 — Honor account- and course-level feature toggles
- Milestone: M1 — Foundations (testing story)
- §5.2 integration point: Feature-flag inheritance (`agents/tasks/feature-1/implementation-research.md`)

## Acceptance criteria covered

| Scenario | Test name | Expected |
|---|---|---|
| Account `allowed/off` + no course override | resolves to false when the account has not enabled the flag and the course has no override | `js_env[:discussion_thread_summarizer_enabled]` → `false` |
| Account `allowed/off` + course override ON | resolves to true when the account is off but the course overrides to on | `js_env[:discussion_thread_summarizer_enabled]` → `true` |
| Account `DEFAULT_ON` + no course override | resolves to true when the account enables for all courses and the course has no override | `js_env[:discussion_thread_summarizer_enabled]` → `true` |
| Account `DEFAULT_ON` + course override OFF | resolves to false when the account enables but the course overrides to off | `js_env[:discussion_thread_summarizer_enabled]` → `false` |

**Note on `STATE_DEFAULT_ON` vs `STATE_ON`:** `enable_feature!` locks the flag to `STATE_ON` (`can_override? = false`), which prevents course-level override and makes scenario 4 impossible. The tests correctly use `set_feature_flag!(flag, Feature::STATE_DEFAULT_ON)` (`allowed_on`) for "account ON" scenarios — this keeps `can_override? = true` so the course flag is consulted, which is the real-world behavior when an account admin enables a flag without locking it.

## Verification

Command: `docker compose exec web bundle exec rspec spec/controllers/discussion_topics_controller_spec.rb -e "feature-flag inheritance chain" --format documentation`

Outcome: exit code 0, **4 examples, 0 failures** (finished in 8.52 seconds, seed 49388)

Matching entry: `agents/tasks/feature-1/qa-lab-evidence.md` Cycle 4

## Scope

This PR adds test code only. No production application code is modified. The "no job enqueued" assertion (acceptance criterion 5, partial) is deferred to the M2/M3 summarization-service slice via a `# TODO (M2/M3)` comment at the top of the new context block, findable with `git grep TODO`.