### PR TITLE
feat(observability): add InstStatsd metric helpers for summarizer

### DIFF
--- a/lib/discussion_thread_summarizer/metrics.rb
+++ b/lib/discussion_thread_summarizer/metrics.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module DiscussionThreadSummarizer
+  # Thin metric helpers for the Discussion Thread Summarizer feature (NFR-4).
+  # Each method wraps a single InstStatsd call with a fixed
+  # discussion_thread_summarizer.* prefix and a consistent tag schema.
+  # Callers are not wired yet; this module is scaffolded in M1 so that M2+
+  # service code can require and call it without touching this file again.
+  module Metrics
+    PREFIX = "discussion_thread_summarizer"
+
+    # Emitted each time a generation is attempted, regardless of outcome.
+    def self.increment_generation_attempt(account:, scope_mode:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.generation.attempt",
+        tags: { account_id: account.global_id, scope_mode: }
+      )
+    end
+
+    # Records end-to-end generation latency in milliseconds.
+    # outcome: one of "success", "error", "timeout", "schema_invalid"
+    def self.record_generation_latency(duration_ms:, account:, outcome:)
+      InstStatsd::Statsd.timing(
+        "#{PREFIX}.generation.latency",
+        duration_ms,
+        tags: { account_id: account.global_id, outcome: }
+      )
+    end
+
+    # Emitted on a cache hit (summary served from cache without model call).
+    def self.increment_cache_hit(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.cache.hit",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Emitted on a cache miss (no usable cached summary; generation queued).
+    def self.increment_cache_miss(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.cache.miss",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Emitted when generation fails for any reason.
+    # reason: one of "quota_exceeded", "throttled", "schema_invalid",
+    #         "transport_error", "unknown"
+    def self.increment_failure(reason:, account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.failure",
+        tags: { account_id: account.global_id, reason: }
+      )
+    end
+
+    # Emitted when a user submits an inaccuracy report against a summary.
+    # reason_category: one of "inaccurate", "missed_viewpoint",
+    #                  "harmful_content", "other"
+    # reporter_role:   "student", "teacher", "admin", or "observer"
+    def self.increment_report_submission(account:, reason_category:, reporter_role:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.report.submission",
+        tags: { account_id: account.global_id, reason_category:, reporter_role: }
+      )
+    end
+  end
+end

--- a/spec/lib/discussion_thread_summarizer/metrics_spec.rb
+++ b/spec/lib/discussion_thread_summarizer/metrics_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+describe DiscussionThreadSummarizer::Metrics do
+  let(:account) { instance_double("Account", global_id: 10_000_000_000_001) }
+
+  before do
+    allow(InstStatsd::Statsd).to receive(:distributed_increment).and_return(nil)
+    allow(InstStatsd::Statsd).to receive(:timing).and_return(nil)
+  end
+
+  describe ".increment_generation_attempt" do
+    it "emits discussion_thread_summarizer.generation.attempt with account_id and scope_mode tags" do
+      described_class.increment_generation_attempt(account:, scope_mode: "default")
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.generation.attempt",
+        tags: { account_id: 10_000_000_000_001, scope_mode: "default" }
+      )
+    end
+  end
+
+  describe ".record_generation_latency" do
+    it "emits discussion_thread_summarizer.generation.latency with duration, account_id, and outcome tags" do
+      described_class.record_generation_latency(duration_ms: 342, account:, outcome: "success")
+      expect(InstStatsd::Statsd).to have_received(:timing).with(
+        "discussion_thread_summarizer.generation.latency",
+        342,
+        tags: { account_id: 10_000_000_000_001, outcome: "success" }
+      )
+    end
+  end
+
+  describe ".increment_cache_hit" do
+    it "emits discussion_thread_summarizer.cache.hit with account_id tag" do
+      described_class.increment_cache_hit(account:)
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.cache.hit",
+        tags: { account_id: 10_000_000_000_001 }
+      )
+    end
+  end
+
+  describe ".increment_cache_miss" do
+    it "emits discussion_thread_summarizer.cache.miss with account_id tag" do
+      described_class.increment_cache_miss(account:)
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.cache.miss",
+        tags: { account_id: 10_000_000_000_001 }
+      )
+    end
+  end
+
+  describe ".increment_failure" do
+    it "emits discussion_thread_summarizer.failure with account_id and reason tags" do
+      described_class.increment_failure(reason: "timeout", account:)
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.failure",
+        tags: { account_id: 10_000_000_000_001, reason: "timeout" }
+      )
+    end
+  end
+
+  describe ".increment_report_submission" do
+    it "emits discussion_thread_summarizer.report.submission with account_id, reason_category, and reporter_role tags" do
+      described_class.increment_report_submission(
+        account:,
+        reason_category: "missed_viewpoint",
+        reporter_role: "student"
+      )
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.report.submission",
+        tags: { account_id: 10_000_000_000_001, reason_category: "missed_viewpoint", reporter_role: "student" }
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Scaffolds `DiscussionThreadSummarizer::Metrics` with six thin `InstStatsd` helper methods (NFR-4, M1 Foundations). No production caller is wired yet; M2+ service code will require and call these without modifying this module.

Closes #4

## Source of truth

- Functional requirement: NFR-4 — Observability (generation latency p50/p95/p99, cache hit rate, error rate by failure mode, daily generation count by account, report submission count by reason category)
- Milestone: M1 — Foundations (observability scaffolding story)
- `agents/tasks/feature-1/implementation-research.md` §4.4 finding 8 (InstStatsd precedent in discussion summary/insight paths)

## Helpers introduced

| Method | Metric name | Tags |
|---|---|---|
| `increment_generation_attempt(account:, scope_mode:)` | `discussion_thread_summarizer.generation.attempt` | `account_id`, `scope_mode` |
| `record_generation_latency(duration_ms:, account:, outcome:)` | `discussion_thread_summarizer.generation.latency` | `account_id`, `outcome` |
| `increment_cache_hit(account:)` | `discussion_thread_summarizer.cache.hit` | `account_id` |
| `increment_cache_miss(account:)` | `discussion_thread_summarizer.cache.miss` | `account_id` |
| `increment_failure(reason:, account:)` | `discussion_thread_summarizer.failure` | `account_id`, `reason` |
| `increment_report_submission(account:, reason_category:, reporter_role:)` | `discussion_thread_summarizer.report.submission` | `account_id`, `reason_category`, `reporter_role` |

**Conventions mirrored:**
- `distributed_increment` for all counters — matches every discussion summary/insight metric in `discussion_topics_api_controller.rb` and is multi-region safe.
- `InstStatsd::Statsd.timing` directly for the latency helper — matches `lib/health_checks.rb`; the block-form `Utils::InstStatsdUtils::Timing.track` wrapper is for code-execution timing, not pre-computed durations.
- `account.global_id` for the `account_id:` tag — cross-shard-safe identifier; `account.id` is only unique within a shard.

## Verification

Command: `docker compose exec web bundle exec rspec spec/lib/discussion_thread_summarizer/metrics_spec.rb --format documentation`

Outcome: exit code 0, **6 examples, 0 failures** (finished in 0.78 seconds, seed 45989)

Matching entry: `agents/tasks/feature-1/qa-lab-evidence.md` Cycle 5

## Scope

This PR introduces `lib/discussion_thread_summarizer/metrics.rb` and its spec only. No files under `app/controllers/`, `app/services/`, `app/jobs/`, `app/models/`, or `config/initializers/` are touched. No dashboard configuration. Dashboard wiring is M8 work.