### PR TITLE
feat(summarizer): add ModelClient interface and StubModelClient

### DIFF
--- a/app/services/discussion_thread_summarizer/model_client.rb
+++ b/app/services/discussion_thread_summarizer/model_client.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module DiscussionThreadSummarizer
+  # Raised by any ModelClient implementation on unrecoverable transport or
+  # service failure. Defined at the namespace level so callers (jobs, controllers)
+  # can rescue DiscussionThreadSummarizer::TransportError without knowing which
+  # concrete client raised it. Future error subclasses (TimeoutError,
+  # RateLimitedError, etc.) will also live at this level; if they multiply,
+  # extract to a dedicated errors.rb at that point.
+  TransportError = Class.new(StandardError)
+
+  # Abstract base class defining the contract every model client must satisfy.
+  # Concrete implementations: StubModelClient (this slice), real HTTP adapter
+  # (a later M2 slice).
+  #
+  # #summarize(payload) must:
+  #   - Accept a Hash payload built by SummarizationService#gather + #pseudonymize.
+  #   - Return a Hash with at minimum:
+  #       :themes         (Array<String>)
+  #       :viewpoints     (Array<String>)
+  #       :open_questions (Array<String>)
+  #       :scope_mode     (String)
+  #   - Raise DiscussionThreadSummarizer::TransportError on any unrecoverable
+  #     transport or service failure so callers can handle it uniformly.
+  class ModelClient
+    def summarize(payload)
+      raise NotImplementedError, "#{self.class}#summarize must be implemented"
+    end
+  end
+end

--- a/app/services/discussion_thread_summarizer/stub_model_client.rb
+++ b/app/services/discussion_thread_summarizer/stub_model_client.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module DiscussionThreadSummarizer
+  # Deterministic ModelClient implementation for use in tests and in local
+  # development before a real model endpoint is wired. Always returns
+  # FIXED_RESPONSE regardless of the payload, making test assertions stable
+  # without any network access.
+  #
+  # To exercise the failure path in tests, subclass or double this client and
+  # configure #summarize to raise DiscussionThreadSummarizer::TransportError.
+  class StubModelClient < ModelClient
+    FIXED_RESPONSE = {
+      themes: ["Main theme A", "Main theme B"],
+      viewpoints: ["Majority viewpoint", "Minority viewpoint"],
+      open_questions: ["What are the next steps?"],
+      scope_mode: "default"
+    }.freeze
+
+    def summarize(_payload)
+      FIXED_RESPONSE
+    end
+  end
+end

--- a/spec/services/discussion_thread_summarizer/model_client_spec.rb
+++ b/spec/services/discussion_thread_summarizer/model_client_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+describe DiscussionThreadSummarizer::ModelClient do
+  describe "#summarize" do
+    it "raises NotImplementedError, enforcing the abstract contract" do
+      client = described_class.new
+      expect { client.summarize({}) }.to raise_error(NotImplementedError, /ModelClient#summarize must be implemented/)
+    end
+  end
+end
+
+describe DiscussionThreadSummarizer::StubModelClient do
+  let(:client) { described_class.new }
+
+  it "is a ModelClient subclass" do
+    expect(client).to be_a(DiscussionThreadSummarizer::ModelClient)
+  end
+
+  describe "#summarize" do
+    it "returns FIXED_RESPONSE unchanged regardless of payload" do
+      result = client.summarize({ topic_id: 999, arbitrary_key: "ignored" })
+      expect(result).to eq(DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE)
+    end
+
+    it "FIXED_RESPONSE includes the four documented contract keys" do
+      response = DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE
+      expect(response).to include(
+        :themes,
+        :viewpoints,
+        :open_questions,
+        :scope_mode
+      )
+      expect(response[:themes]).to be_an(Array)
+      expect(response[:viewpoints]).to be_an(Array)
+      expect(response[:open_questions]).to be_an(Array)
+      expect(response[:scope_mode]).to be_a(String)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Defines the model-client contract for the Discussion Thread Summarizer (M2 — Summarization service). Ships the abstract `ModelClient` base class, the deterministic `StubModelClient` for tests and local development, and the namespace-level `TransportError`. No callers wired; the `SummarizationService` orchestrator (issue #6) depends on this interface and lands in the next slice.

Closes #7

## Source of truth

- Functional requirement: FR-1 — Generate per-thread summary on demand; NFR-5 — Reliability and graceful degradation
- Milestone: M2 — Summarization service
- `agents/tasks/feature-1/implementation-research.md` §4.4 finding 8 (RubricLLMService as model-client precedent)

## What ships

| File | Role |
|---|---|
| `app/services/discussion_thread_summarizer/model_client.rb` | Abstract base class + `TransportError` |
| `app/services/discussion_thread_summarizer/stub_model_client.rb` | Deterministic stub returning `FIXED_RESPONSE` |
| `spec/services/discussion_thread_summarizer/model_client_spec.rb` | 4 examples proving contract + stub |

## Design decisions

**`TransportError` at namespace level** (`DiscussionThreadSummarizer::TransportError`, not `ModelClient::TransportError`). Future job and controller code rescues one domain error without knowing which concrete client raised it. Consistent with `CanvasHttp::Error` and `InstLLM::ServiceQuotaExceededError`. When more error subclasses arrive (M2/M8), they sit at the same level; if they multiply, extract to `errors.rb` at that point.

**Layout mirrors `AiExperiences::*` services**, not `RubricLLMService`. `RubricLLMService` is monolithic-flat in one large file; the Canvas convention for new namespaced features is one class per file in a directory mirroring the namespace, as `AiExperiences::ConversationStartService` demonstrates. `RubricLLMService` informed the payload-in / structured-response-out contract shape but was unsuitable as a layout precedent.

## Verification

Command: `docker compose exec web bundle exec rspec spec/services/discussion_thread_summarizer/model_client_spec.rb --format documentation`

Outcome: exit code 0, **4 examples, 0 failures** (0.77 seconds, seed 58513)

Matching entry: `agents/tasks/feature-1/qa-lab-evidence.md` Cycle 6

## Scope

This PR adds two service files and one spec. No controllers, views, jobs, models, GraphQL, or config files touched. The `SummarizationService` orchestrator (issue #6) is the next slice on branch `feat/m2-summarization-service-scaffold`.