### PR TITLE
[M2] Summarization service scaffold (issue #6)

### DIFF
--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module DiscussionThreadSummarizer
+  # Orchestrates the per-thread summary pipeline:
+  #   gather → pseudonymize → client.summarize → validate → return result
+  #
+  # This is the only code path that calls the model client. Controllers, jobs,
+  # and cache layers all go through here, never through the client directly.
+  #
+  # The three private pipeline stubs (gather, pseudonymize, validate) are
+  # no-ops in this scaffold slice. Each carries a comment naming the future
+  # slice that replaces it with real logic.
+  class SummarizationService
+    def initialize(client: StubModelClient.new)
+      @client = client
+    end
+
+    def summarize(discussion_topic:, viewer:)
+      payload = gather(discussion_topic, viewer)
+      payload = pseudonymize(payload)
+      result  = @client.summarize(payload)
+      validate(result)
+      result
+    end
+
+    private
+
+    def gather(discussion_topic, _viewer)
+      # Stub: real content extraction lands in a later M2 slice.
+      { topic_id: discussion_topic.id }
+    end
+
+    def pseudonymize(payload)
+      # Stub: real author pseudonymization lands in issue #8.
+      payload
+    end
+
+    def validate(_result)
+      # Stub: real validator (issue #10) raises on schema violation; this is a no-op.
+      nil
+    end
+  end
+end

--- a/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
+++ b/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+describe DiscussionThreadSummarizer::SummarizationService do
+  let(:stub_client) { DiscussionThreadSummarizer::StubModelClient.new }
+  let(:service)     { described_class.new(client: stub_client) }
+  let(:topic)       { instance_double("DiscussionTopic", id: 42) }
+  let(:viewer)      { instance_double("User") }
+
+  describe "#summarize" do
+    it "calls the injected client with a payload derived from the topic" do
+      allow(stub_client).to receive(:summarize).and_call_original
+      service.summarize(discussion_topic: topic, viewer:)
+      expect(stub_client).to have_received(:summarize).with(hash_including(topic_id: 42))
+    end
+
+    it "returns the client's output unchanged in this skeleton" do
+      result = service.summarize(discussion_topic: topic, viewer:)
+      expect(result).to eq(DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE)
+    end
+
+    it "accepts any ModelClient implementation (dependency injection)" do
+      custom_client = Class.new(DiscussionThreadSummarizer::ModelClient) do
+        def summarize(_payload)
+          { themes: ["from custom client"], viewpoints: [], open_questions: [], scope_mode: "default" }
+        end
+      end.new
+
+      result = described_class.new(client: custom_client)
+                              .summarize(discussion_topic: topic, viewer:)
+      expect(result[:themes]).to eq(["from custom client"])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `DiscussionThreadSummarizer::SummarizationService` — the orchestrator for the per-thread summary pipeline.

**Pipeline (this slice: all stubs):**
```
gather(topic, viewer) → pseudonymize(payload) → @client.summarize(payload) → validate(result) → result
```

**Files changed (2):**
- `app/services/discussion_thread_summarizer/summarization_service.rb` — orchestrator; constructor injects any `ModelClient` via keyword arg (default: `StubModelClient`)
- `spec/services/discussion_thread_summarizer/summarization_service_spec.rb` — three examples proving payload derivation, return-value pass-through, and DI substitutability

**Stub contract notes:**
- `gather`: yields `{ topic_id: discussion_topic.id }`; `_viewer` unused (real scope-limit logic lands in a later M2 slice)
- `pseudonymize`: pass-through; real author name replacement lands in issue #8
- `validate(_result)`: returns `nil`; real validator (issue #10) raises on schema violation — return value is always discarded

**Design precedent:** `AiExperiences::ConversationStartService` — namespaced service with kwarg-injected collaborator, single public action method, no `ApplicationService` base class.

Depends on: PR #61 (Cycle 6 — `ModelClient` + `StubModelClient`)

Closes #6

## QA result

```
3 examples, 0 failures  (green first run)
```

Command:
```bash
docker compose exec web bundle exec rspec   spec/services/discussion_thread_summarizer/summarization_service_spec.rb   --format documentation
```