### PR TITLE
[M2] Pseudonymization transform (closes #8)

### DIFF
--- a/app/services/discussion_thread_summarizer/pseudonymizer.rb
+++ b/app/services/discussion_thread_summarizer/pseudonymizer.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module DiscussionThreadSummarizer
+  # Replaces each entry's :author_name with a stable per-thread pseudonym
+  # ("Author A", "Author B", …) before any content crosses the application
+  # boundary to the model client.
+  #
+  # Assignment is first-seen: the first distinct author encountered receives
+  # "Author A", the second "Author B", and so on. The mapping is deterministic
+  # within a single call but is NOT persisted across requests.
+  #
+  # Returns a Result with:
+  #   pseudonymized_entries — the transformed array (new hashes; input not mutated)
+  #   author_map            — { real_name => label } for potential UI re-insertion
+  #
+  # The caller (SummarizationService) currently discards author_map. When M4
+  # introduces summary rendering that references pseudonyms, the map will need
+  # to be threaded through the service's return value.
+  class Pseudonymizer
+    Result = Struct.new(:pseudonymized_entries, :author_map)
+
+    def self.call(entries)
+      new.call(entries)
+    end
+
+    def call(entries)
+      author_map = {}
+      counter    = 0
+
+      pseudonymized = entries.map do |entry|
+        real_name = entry[:author_name]
+        unless author_map.key?(real_name)
+          author_map[real_name] = "Author #{("A".ord + counter).chr}"
+          counter += 1
+        end
+        entry.merge(author_name: author_map[real_name])
+      end
+
+      Result.new(pseudonymized, author_map.freeze)
+    end
+  end
+end

--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -49,8 +49,12 @@ module DiscussionThreadSummarizer
     end
 
     def pseudonymize(payload)
-      # Stub: real author pseudonymization lands in issue #8.
-      payload
+      entries = payload[:entries]
+      return payload if entries.nil? || entries.empty?
+
+      result = Pseudonymizer.call(entries)
+      # author_map stays in memory only — never logged or forwarded.
+      payload.merge(entries: result.pseudonymized_entries)
     end
 
     def validate(_result)

--- a/spec/services/discussion_thread_summarizer/pseudonymizer_spec.rb
+++ b/spec/services/discussion_thread_summarizer/pseudonymizer_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+describe DiscussionThreadSummarizer::Pseudonymizer do
+  # Three-author fixture reused across happy-path examples.
+  let(:entries) do
+    [
+      { author_name: "Alice", body: "post one"   },
+      { author_name: "Bob",   body: "post two"   },
+      { author_name: "Carol", body: "post three" },
+      { author_name: "Alice", body: "post four"  },
+    ]
+  end
+
+  subject(:result) { described_class.call(entries) }
+
+  # ── Happy-path contract ──────────────────────────────────────────────────
+
+  it "replaces all real author names with pseudonyms in the returned entries" do
+    names = result.pseudonymized_entries.map { |e| e[:author_name] }
+    expect(names).not_to include("Alice", "Bob", "Carol")
+    expect(names).to all(match(/\AAuthor [A-Z]\z/))
+  end
+
+  it "assigns the same label to the same author within a single call (stability)" do
+    alice_labels = result.pseudonymized_entries
+                         .select { |e| e[:body].include?("Alice") rescue false }
+
+    # locate entries that were originally Alice's by body content
+    original_alice_bodies = ["post one", "post four"]
+    alice_entries = result.pseudonymized_entries.select { |e| original_alice_bodies.include?(e[:body]) }
+    expect(alice_entries.map { |e| e[:author_name] }.uniq.size).to eq(1)
+  end
+
+  it "assigns distinct labels to distinct authors (no collisions)" do
+    labels = result.pseudonymized_entries.map { |e| e[:author_name] }.uniq
+    expect(labels.size).to eq(3)
+  end
+
+  it "preserves :body text unchanged" do
+    original_bodies = entries.map { |e| e[:body] }
+    returned_bodies = result.pseudonymized_entries.map { |e| e[:body] }
+    expect(returned_bodies).to eq(original_bodies)
+  end
+
+  it "returns an author_map pairing each real name to its label" do
+    expect(result.author_map["Alice"]).to match(/\AAuthor [A-Z]\z/)
+    expect(result.author_map["Bob"]).to match(/\AAuthor [A-Z]\z/)
+    expect(result.author_map["Carol"]).to match(/\AAuthor [A-Z]\z/)
+    expect(result.author_map["Alice"]).not_to eq(result.author_map["Bob"])
+  end
+
+  # ── Edge cases ───────────────────────────────────────────────────────────
+
+  it "returns empty pseudonymized_entries and empty author_map for an empty input" do
+    r = described_class.call([])
+    expect(r.pseudonymized_entries).to eq([])
+    expect(r.author_map).to eq({})
+  end
+
+  it "produces exactly one author_map entry when a single author is repeated" do
+    repeated = [
+      { author_name: "Alice", body: "a" },
+      { author_name: "Alice", body: "b" },
+      { author_name: "Alice", body: "c" },
+    ]
+    r = described_class.call(repeated)
+    expect(r.author_map.size).to eq(1)
+    expect(r.pseudonymized_entries.map { |e| e[:author_name] }.uniq).to eq(["Author A"])
+  end
+
+  # ── Label contract ───────────────────────────────────────────────────────
+
+  it "assigns labels in first-seen order (first author gets A, second gets B, …)" do
+    # Alice appears first → Author A; Bob second → Author B; Carol third → Author C
+    expect(result.author_map["Alice"]).to eq("Author A")
+    expect(result.author_map["Bob"]).to  eq("Author B")
+    expect(result.author_map["Carol"]).to eq("Author C")
+  end
+
+  it "uses the exact format 'Author X' (capital A, space, uppercase letter)" do
+    result.author_map.each_value do |label|
+      expect(label).to match(/\AAuthor [A-Z]\z/),
+                       "expected label to be 'Author X' format, got: #{label.inspect}"
+    end
+  end
+
+  # ── Immutability ─────────────────────────────────────────────────────────
+
+  it "does not mutate the original entry hashes" do
+    originals = entries.map(&:dup)
+    described_class.call(entries)
+    expect(entries).to eq(originals)
+  end
+end

--- a/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
+++ b/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
@@ -46,5 +46,33 @@ describe DiscussionThreadSummarizer::SummarizationService do
                               .summarize(discussion_topic: topic, viewer:)
       expect(result[:themes]).to eq(["from custom client"])
     end
+
+    it "strips real author names from the payload when entries are present" do
+      capturing_client = Class.new(DiscussionThreadSummarizer::ModelClient) do
+        attr_reader :received_payload
+
+        def summarize(payload)
+          @received_payload = payload
+          { themes: [], viewpoints: [], open_questions: [], scope_mode: "default" }
+        end
+      end.new
+
+      svc = described_class.new(client: capturing_client)
+      allow(svc).to receive(:gather).and_return(
+        {
+          topic_id: 42,
+          entries:  [
+            { author_name: "Alice", body: "post one"   },
+            { author_name: "Bob",   body: "post two"   },
+            { author_name: "Alice", body: "post three" },
+          ]
+        }
+      )
+      svc.summarize(discussion_topic: topic, viewer:)
+
+      received_names = capturing_client.received_payload[:entries].map { |e| e[:author_name] }
+      expect(received_names).to eq(["Author A", "Author B", "Author A"])
+      expect(received_names).not_to include("Alice", "Bob")
+    end
   end
 end


### PR DESCRIPTION
[M2] Pseudonymization transform.

Adds Pseudonymizer.call(entries): returns pseudonymized_entries + author_map.
Service pseudonymize step updated; gracefully no-ops when :entries absent.
10 pseudonymizer examples + 1 new service spec example, all green.

Design: author_map computed-and-dropped now; M4 rendering will thread it through.
Order: #8 before #9 (board blocked-by graph).

Closes #8