### PR TITLE
[M2] Output schema validator (closes #10)

### DIFF
--- a/app/services/discussion_thread_summarizer/output_schema_validator.rb
+++ b/app/services/discussion_thread_summarizer/output_schema_validator.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module DiscussionThreadSummarizer
+  # Raised when the model's response fails schema validation. Declared at the
+  # namespace level (alongside TransportError) so callers can rescue
+  # DiscussionThreadSummarizer::SchemaViolationError without knowing the
+  # validator class. Mirrors the TransportError precedent from Cycle 6.
+  SchemaViolationError = Class.new(StandardError)
+
+  # Pure raise-on-invalid schema guard for model output hashes.
+  # Mirrors the guard-before-persist pattern in DiscussionTopicInsight#validate_llm_response
+  # (app/models/discussion_topic_insight.rb:167).
+  #
+  # .call(result) raises SchemaViolationError or returns nil (silent pass).
+  # No transformation, coercion, or normalization — only structural checks.
+  #
+  # Metric emission on rejection lives in SummarizationService#summarize (the
+  # boundary where the account is already in scope), not here.
+  class OutputSchemaValidator
+    MAX_ARRAY_LENGTH    = 20
+    MAX_STRING_LENGTH   = 500
+    MAX_SCOPE_MODE_LENGTH = 50
+
+    ARRAY_KEYS = %i[themes viewpoints open_questions].freeze
+
+    def self.call(result)
+      new.call(result)
+    end
+
+    def call(result)
+      validate_hash_type(result)
+      validate_array_keys(result)
+      validate_scope_mode(result)
+      nil
+    end
+
+    private
+
+    def validate_hash_type(result)
+      return if result.is_a?(Hash)
+
+      raise SchemaViolationError, "response must be a Hash, got #{result.class}"
+    end
+
+    def validate_array_keys(result)
+      ARRAY_KEYS.each do |key|
+        value = result[key]
+
+        raise SchemaViolationError, ":#{key} is required" if value.nil?
+        raise SchemaViolationError, ":#{key} must be an Array, got #{value.class}" unless value.is_a?(Array)
+        if value.size > MAX_ARRAY_LENGTH
+          raise SchemaViolationError, ":#{key} exceeds maximum length of #{MAX_ARRAY_LENGTH} items"
+        end
+
+        value.each_with_index do |element, i|
+          unless element.is_a?(String)
+            raise SchemaViolationError, ":#{key}[#{i}] must be a String, got #{element.class}"
+          end
+          if element.length > MAX_STRING_LENGTH
+            raise SchemaViolationError, ":#{key}[#{i}] exceeds maximum string length of #{MAX_STRING_LENGTH}"
+          end
+        end
+      end
+    end
+
+    def validate_scope_mode(result)
+      sm = result[:scope_mode]
+
+      raise SchemaViolationError, ":scope_mode is required" if sm.nil?
+      raise SchemaViolationError, ":scope_mode must be a String, got #{sm.class}" unless sm.is_a?(String)
+      if sm.length > MAX_SCOPE_MODE_LENGTH
+        raise SchemaViolationError, ":scope_mode exceeds maximum length of #{MAX_SCOPE_MODE_LENGTH}"
+      end
+    end
+  end
+end

--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -34,10 +34,16 @@ module DiscussionThreadSummarizer
     end
 
     def summarize(discussion_topic:, viewer:)
+      account = discussion_topic.context.root_account
       payload = gather(discussion_topic, viewer)
       payload = pseudonymize(payload)
       result  = @client.summarize(payload)
-      validate(result)
+      begin
+        validate(result)
+      rescue DiscussionThreadSummarizer::SchemaViolationError
+        Metrics.increment_failure(reason: "schema_invalid", account:)
+        raise
+      end
       result
     end
 
@@ -90,9 +96,8 @@ module DiscussionThreadSummarizer
       payload.merge(entries: result.pseudonymized_entries)
     end
 
-    def validate(_result)
-      # Stub: real validator (issue #10) raises on schema violation; this is a no-op.
-      nil
+    def validate(result)
+      OutputSchemaValidator.call(result)
     end
   end
 end

--- a/spec/services/discussion_thread_summarizer/output_schema_validator_spec.rb
+++ b/spec/services/discussion_thread_summarizer/output_schema_validator_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+describe DiscussionThreadSummarizer::OutputSchemaValidator do
+  subject(:validator) { described_class }
+
+  let(:valid_response) do
+    {
+      themes:         ["Theme A", "Theme B"],
+      viewpoints:     ["Viewpoint 1"],
+      open_questions: ["Q1?"],
+      scope_mode:     "default"
+    }
+  end
+
+  # ── Happy path ────────────────────────────────────────────────────────────
+
+  it "returns nil and does not raise for a valid four-key response" do
+    expect { validator.call(valid_response) }.not_to raise_error
+    expect(validator.call(valid_response)).to be_nil
+  end
+
+  it "passes StubModelClient::FIXED_RESPONSE unchanged (regression guard)" do
+    expect do
+      validator.call(DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE)
+    end.not_to raise_error
+  end
+
+  # ── Missing required keys ─────────────────────────────────────────────────
+
+  it "raises SchemaViolationError when :themes is missing" do
+    expect { validator.call(valid_response.except(:themes)) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /:themes/)
+  end
+
+  it "raises SchemaViolationError when :viewpoints is missing" do
+    expect { validator.call(valid_response.except(:viewpoints)) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /:viewpoints/)
+  end
+
+  it "raises SchemaViolationError when :open_questions is missing" do
+    expect { validator.call(valid_response.except(:open_questions)) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /:open_questions/)
+  end
+
+  it "raises SchemaViolationError when :scope_mode is missing" do
+    expect { validator.call(valid_response.except(:scope_mode)) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /:scope_mode/)
+  end
+
+  # ── Type mismatches ───────────────────────────────────────────────────────
+
+  it "raises SchemaViolationError when :themes is a String instead of Array" do
+    expect { validator.call(valid_response.merge(themes: "not an array")) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /:themes must be an Array/)
+  end
+
+  it "raises SchemaViolationError when :scope_mode is an Array instead of String" do
+    expect { validator.call(valid_response.merge(scope_mode: ["oops"])) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /:scope_mode must be a String/)
+  end
+
+  # ── Nested element type ───────────────────────────────────────────────────
+
+  it "raises SchemaViolationError when :themes contains a non-String element" do
+    expect { validator.call(valid_response.merge(themes: [1, 2, 3])) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /:themes\[0\] must be a String/)
+  end
+
+  # ── Size limits ───────────────────────────────────────────────────────────
+
+  it "raises SchemaViolationError when :themes array exceeds MAX_ARRAY_LENGTH" do
+    oversized = Array.new(described_class::MAX_ARRAY_LENGTH + 1, "item")
+    expect { validator.call(valid_response.merge(themes: oversized)) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /exceeds maximum length/)
+  end
+
+  it "raises SchemaViolationError when a :themes element exceeds MAX_STRING_LENGTH" do
+    long_string = "x" * (described_class::MAX_STRING_LENGTH + 1)
+    expect { validator.call(valid_response.merge(themes: [long_string])) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /exceeds maximum string length/)
+  end
+
+  it "raises SchemaViolationError when :scope_mode exceeds MAX_SCOPE_MODE_LENGTH" do
+    long_scope = "s" * (described_class::MAX_SCOPE_MODE_LENGTH + 1)
+    expect { validator.call(valid_response.merge(scope_mode: long_scope)) }
+      .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /exceeds maximum length/)
+  end
+
+  # ── Top-level type guard ──────────────────────────────────────────────────
+
+  it "raises SchemaViolationError when result is not a Hash" do
+    [nil, [], "string", 42].each do |bad_value|
+      expect { validator.call(bad_value) }
+        .to raise_error(DiscussionThreadSummarizer::SchemaViolationError, /must be a Hash/),
+            "expected SchemaViolationError for #{bad_value.inspect}"
+    end
+  end
+end

--- a/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
+++ b/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
@@ -18,7 +18,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
 describe DiscussionThreadSummarizer::SummarizationService do
-  let(:root_account)     { instance_double("Account") }
+  let(:root_account)     { instance_double("Account", global_id: 10_000_000_000_001) }
   let(:course)           { instance_double("Course", root_account:) }
   let(:stub_client)      { DiscussionThreadSummarizer::StubModelClient.new }
   let(:service)          { described_class.new(client: stub_client) }
@@ -91,6 +91,37 @@ describe DiscussionThreadSummarizer::SummarizationService do
       received_names = capturing_client.received_payload[:entries].map { |e| e[:author_name] }
       expect(received_names).to eq(["Author A", "Author B", "Author A"])
       expect(received_names).not_to include("Alice", "Bob")
+    end
+  end
+
+  # ── Schema validator wiring (Cycle 10) ───────────────────────────────────
+
+  context "schema validation" do
+    let(:malformed_client) do
+      Class.new(DiscussionThreadSummarizer::ModelClient) do
+        def summarize(_payload)
+          { themes: nil }  # missing required keys + wrong type
+        end
+      end.new
+    end
+
+    it "propagates SchemaViolationError when the client returns malformed output" do
+      svc = described_class.new(client: malformed_client)
+      expect { svc.summarize(discussion_topic: topic, viewer:) }
+        .to raise_error(DiscussionThreadSummarizer::SchemaViolationError)
+    end
+
+    it "emits failure metric with reason 'schema_invalid' before re-raising" do
+      allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_failure)
+      svc = described_class.new(client: malformed_client)
+
+      expect { svc.summarize(discussion_topic: topic, viewer:) }
+        .to raise_error(DiscussionThreadSummarizer::SchemaViolationError)
+
+      expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_failure).with(
+        reason:  "schema_invalid",
+        account: root_account
+      )
     end
   end
 


### PR DESCRIPTION
Pure raise-on-invalid schema guard for model output hashes.

SchemaViolationError declared at namespace level (alongside TransportError).
Metric emission in service rescue block (account already in scope).
13 validator examples + 2 service wiring examples = 25 total, 0 failures.

Closes #10