### PR TITLE
[M3] Content-version hash computation for cache keying (closes #15)

### DIFF
--- a/app/services/discussion_thread_summarizer/content_version_hash.rb
+++ b/app/services/discussion_thread_summarizer/content_version_hash.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module DiscussionThreadSummarizer
+  # Computes a deterministic SHA-256 content-version hash for a discussion
+  # topic's current reply state, for use as a cache key in M3.
+  #
+  # The hash covers every non-deleted entry's id and message body, sorted by
+  # id for determinism. It changes when:
+  #   - a new entry is created
+  #   - an entry is soft-deleted (workflow_state → "deleted")
+  #   - an entry's message body is edited
+  #
+  # Mirrors the algorithm in DiscussionTopicInsight::Entry.hash_for_dynamic_content
+  # (app/models/discussion_topic_insight/entry.rb:43–50): Digest::SHA256.hexdigest
+  # over a JSON-serialised structured value, producing a 64-char lowercase hex
+  # string. No user identity is included — avoiding per-viewer cache fragmentation.
+  #
+  # Pure utility: no DB writes, no cache interaction, no side effects.
+  class ContentVersionHash
+    # Returns a 64-char lowercase hex SHA-256 digest representing the topic's
+    # current active reply state. Returns a stable digest of an empty array
+    # when the topic has no active entries.
+    #
+    # Raises ArgumentError if discussion_topic is nil.
+    def self.call(discussion_topic)
+      raise ArgumentError, "discussion_topic must not be nil" if discussion_topic.nil?
+
+      rows = discussion_topic
+               .discussion_entries
+               .active
+               .order(:id)
+               .pluck(:id, :message)
+
+      tuples = rows.map { |id, msg| { id:, message: msg.to_s } }
+      Digest::SHA256.hexdigest(tuples.to_json)
+    end
+  end
+end

--- a/spec/services/discussion_thread_summarizer/content_version_hash_spec.rb
+++ b/spec/services/discussion_thread_summarizer/content_version_hash_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+describe DiscussionThreadSummarizer::ContentVersionHash do
+  # DB-backed: exercises the .active scope and real AR queries.
+  let(:course) { course_model }
+  let(:user)   { user_model }
+  let(:topic)  { course.discussion_topics.create! }
+
+  subject(:call) { described_class.call(topic) }
+
+  # ── Output format ────────────────────────────────────────────────────────
+
+  it "returns a 64-character lowercase hex string (SHA-256 hexdigest format)" do
+    expect(call).to match(/\A[0-9a-f]{64}\z/)
+  end
+
+  # ── Determinism (core invariant) ─────────────────────────────────────────
+
+  it "returns the same hash for the same topic state on repeated calls (determinism)" do
+    topic.discussion_entries.create!(user:, message: "hello")
+
+    first  = described_class.call(topic)
+    second = described_class.call(topic)
+
+    expect(first).to eq(second)
+  end
+
+  # ── Empty topic ───────────────────────────────────────────────────────────
+
+  it "returns a deterministic non-nil hash for a topic with no active entries" do
+    result = described_class.call(topic)
+
+    expect(result).not_to be_nil
+    expect(result).to match(/\A[0-9a-f]{64}\z/)
+    expect(result).to eq(described_class.call(topic))
+  end
+
+  # ── Two different topics ──────────────────────────────────────────────────
+
+  it "returns different hashes for two topics with different entries" do
+    topic_a = course.discussion_topics.create!
+    topic_b = course.discussion_topics.create!
+    topic_a.discussion_entries.create!(user:, message: "unique content A")
+    topic_b.discussion_entries.create!(user:, message: "unique content B")
+
+    expect(described_class.call(topic_a)).not_to eq(described_class.call(topic_b))
+  end
+
+  # ── New entry added ───────────────────────────────────────────────────────
+
+  it "changes hash when a new entry is added to the topic" do
+    before_add = described_class.call(topic)
+    topic.discussion_entries.create!(user:, message: "new reply")
+    after_add  = described_class.call(topic)
+
+    expect(before_add).not_to eq(after_add)
+  end
+
+  # ── Soft-delete ───────────────────────────────────────────────────────────
+
+  it "changes hash when an entry is soft-deleted (excluded from .active scope)" do
+    entry = topic.discussion_entries.create!(user:, message: "will be deleted")
+    hash_before = described_class.call(topic)
+
+    entry.update!(workflow_state: "deleted")
+    hash_after  = described_class.call(topic)
+
+    expect(hash_before).not_to eq(hash_after)
+  end
+
+  it "produces the same hash as an empty topic after soft-deleting the only entry" do
+    empty_hash = described_class.call(topic)
+
+    entry = topic.discussion_entries.create!(user:, message: "goes away")
+    entry.update!(workflow_state: "deleted")
+
+    expect(described_class.call(topic)).to eq(empty_hash)
+  end
+
+  # ── Message edit ─────────────────────────────────────────────────────────
+
+  it "changes hash when an entry's message body is edited (content is part of the hash)" do
+    entry = topic.discussion_entries.create!(user:, message: "original text")
+    hash_before = described_class.call(topic)
+
+    entry.update_column(:message, "edited text")
+    hash_after  = described_class.call(topic)
+
+    expect(hash_before).not_to eq(hash_after)
+  end
+
+  # ── nil guard ─────────────────────────────────────────────────────────────
+
+  it "raises ArgumentError when discussion_topic is nil" do
+    expect { described_class.call(nil) }.to raise_error(ArgumentError, /discussion_topic must not be nil/)
+  end
+end


### PR DESCRIPTION
## Summary

Introduces `DiscussionThreadSummarizer::ContentVersionHash` — a pure utility class that computes a deterministic SHA-256 content-version hash over a discussion topic's current active reply set. This is the cache-key primitive for M3; it produces the stable string that slices #16 (cache write) and #17 (invalidation) will read and compare.

## Approach

**Algorithm:** `Digest::SHA256.hexdigest(tuples.to_json)` → 64-char lowercase hex string, mirroring the canonical Canvas pattern in `DiscussionTopicInsight::Entry.hash_for_dynamic_content` (`app/models/discussion_topic_insight/entry.rb:43–50`).

**Input set:** sorted-by-id array of `{id:, message:}` tuples for all non-deleted entries (`discussion_entries.active.order(:id)`). Includes message content (not just IDs) so edits change the hash — matching the precedent's content-hashing behavior. No user identity; no locale; no config version. `DiscussionEntry.active` scope (`where.not(workflow_state: "deleted")`) matches Canvas convention at `app/models/discussion_entry.rb:456`.

**Output:** 64-char hex fits `DiscussionTopicSummary.dynamic_content_hash` (varchar 255, confirmed in migration) and `DiscussionTopicInsight::Entry.dynamic_content_hash` (varchar 64).

**Threshold note:** Issue #15 describes a token-count threshold so minor typo edits do not bust the cache. That refinement is left for slice #16/#17 to layer on top; this slice delivers the core deterministic primitive the threshold logic will consume.

## Files changed

| File | Action |
|------|--------|
| `app/services/discussion_thread_summarizer/content_version_hash.rb` | New |
| `spec/services/discussion_thread_summarizer/content_version_hash_spec.rb` | New |

No changes to `summarization_service.rb` or any existing file.

## Test results

```
docker compose exec web bundle exec rspec \
  spec/services/discussion_thread_summarizer/content_version_hash_spec.rb \
  --format documentation

9 examples, 0 failures
```

## Test plan

- [ ] `docker compose exec web bundle exec rspec spec/services/discussion_thread_summarizer/content_version_hash_spec.rb --format documentation` → 9 examples, 0 failures
- [ ] Verify determinism example: same topic state twice → equal hashes
- [ ] Verify soft-delete: entry with `workflow_state: "deleted"` excluded from hash
- [ ] Verify nil guard: `ContentVersionHash.call(nil)` raises `ArgumentError`

closes #15
flag=none