### PR TITLE
[M3] Cache read/write via fetch_or_create_summary (closes #16)

### DIFF
--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -25,6 +25,10 @@ module DiscussionThreadSummarizer
   # This is the only code path that calls the model client. Controllers, jobs,
   # and cache layers all go through here, never through the client directly.
   class SummarizationService
+    LLM_CONFIG_VERSION = "thread-summarizer-v1"
+
+    CacheResult = Struct.new(:status, :record, :result, keyword_init: true)
+
     # Enqueues a background summary attempt via Delayed Job.
     # Mirrors the insight_generation pattern in DiscussionTopicsApiController.
     # Singleton + n_strand ensure at most one job per topic runs at a time.
@@ -33,11 +37,39 @@ module DiscussionThreadSummarizer
         priority: Delayed::HIGH_PRIORITY,
         singleton: "discussion_thread_summarizer:generation_for_topic:#{discussion_topic.id}",
         n_strand: ["discussion_thread_summarizer:generation:#{Shard.current.database_server.region}", 1]
-      ).summarize(discussion_topic:, viewer:)
+      ).fetch_or_create_summary(discussion_topic:, viewer:)
     end
 
     def initialize(client: StubModelClient.new)
       @client = client
+    end
+
+    # Cache-aware entrypoint: O(1) lookup by content hash + config version + locale.
+    # On hit, returns stored summary without calling the model client.
+    def fetch_or_create_summary(discussion_topic:, viewer:, locale: I18n.locale.to_s)
+      account      = discussion_topic.context.root_account
+      content_hash = ContentVersionHash.call(discussion_topic)
+      cached       = find_cached_summary(discussion_topic, content_hash, locale)
+
+      if cached
+        DiscussionThreadSummarizer::Metrics.increment_cache_hit(account:)
+        return CacheResult.new(
+          status: :hit,
+          record: cached,
+          result: parse_summary_record(cached)
+        )
+      end
+
+      DiscussionThreadSummarizer::Metrics.increment_cache_miss(account:)
+      result = summarize(discussion_topic:, viewer:)
+      record = persist_summary_record(
+        discussion_topic:,
+        viewer:,
+        locale:,
+        content_hash:,
+        result:
+      )
+      CacheResult.new(status: :miss, record: record, result: result)
     end
 
     def summarize(discussion_topic:, viewer:)
@@ -70,6 +102,39 @@ module DiscussionThreadSummarizer
     end
 
     private
+
+    def find_cached_summary(discussion_topic, content_hash, locale)
+      # NOTE: Cache key assumes discussion_thread_summarizer_scope_limited is OFF.
+      # When enabled, gather filters entries by viewer while ContentVersionHash hashes
+      # the unfiltered .active set, so this key can return cross-viewer wrong results.
+      # Before enabling scope_limited in production, add scope_mode to the cache key
+      # or include viewer-filtered entry IDs in the hash. Tracked in
+      # https://github.com/ejgdr/canvas-lms/issues/85.
+      discussion_topic.summaries
+                      .where(
+                        llm_config_version: LLM_CONFIG_VERSION,
+                        dynamic_content_hash: content_hash,
+                        parent_id: nil,
+                        locale:
+                      )
+                      .order(created_at: :desc)
+                      .first
+    end
+
+    def persist_summary_record(discussion_topic:, viewer:, locale:, content_hash:, result:)
+      discussion_topic.summaries.create!(
+        llm_config_version: LLM_CONFIG_VERSION,
+        dynamic_content_hash: content_hash,
+        user: viewer,
+        locale:,
+        summary: result.to_json,
+        parent_id: nil
+      )
+    end
+
+    def parse_summary_record(record)
+      JSON.parse(record.summary, symbolize_names: true)
+    end
 
     def gather(discussion_topic, viewer)
       course        = discussion_topic.context

--- a/spec/services/discussion_thread_summarizer/integration/async_summarization_spec.rb
+++ b/spec/services/discussion_thread_summarizer/integration/async_summarization_spec.rb
@@ -22,9 +22,8 @@
 # Uses real AR fixtures (Course, DiscussionTopic, DiscussionEntry, User) and
 # drives Delayed Job through its real execution path via run_jobs/run_job.
 #
-# Scope: M2 async pipeline only.
-# AC2 (DiscussionTopicSummary record with dynamic_content_hash) is deferred to
-# M3 (slice #16): the service does not yet write cache records.
+# Scope: M2 async pipeline + M3 cache write (Cycle 16).
+# AC2: after run_jobs, one DiscussionTopicSummary row with expected dynamic_content_hash.
 # "Thread open" is simulated by direct enqueue_for calls — controller wiring
 # is M4 work.
 
@@ -109,5 +108,12 @@ describe "DiscussionThreadSummarizer::SummarizationService async integration" do
     expect(audit[:thread_id]).to eq(topic.id)
 
     expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_failure)
+
+    expected_hash = DiscussionThreadSummarizer::ContentVersionHash.call(topic)
+    summaries = DiscussionTopicSummary.where(discussion_topic: topic)
+    expect(summaries.count).to eq(1)
+    expect(summaries.first.dynamic_content_hash).to eq(expected_hash)
+    expect(summaries.first.llm_config_version)
+      .to eq(DiscussionThreadSummarizer::SummarizationService::LLM_CONFIG_VERSION)
   end
 end

--- a/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
+++ b/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
@@ -63,7 +63,7 @@ describe DiscussionThreadSummarizer::SummarizationService do
   # ── Async enqueueing via .enqueue_for (Cycle 12) ─────────────────────────
 
   describe ".enqueue_for" do
-    let(:delay_proxy) { instance_double(described_class, summarize: nil) }
+    let(:delay_proxy) { instance_double(described_class, fetch_or_create_summary: nil) }
 
     it "dispatches with HIGH_PRIORITY, singleton scoped to the topic id, and n_strand with region" do
       expected_singleton = "discussion_thread_summarizer:generation_for_topic:42"
@@ -80,9 +80,9 @@ describe DiscussionThreadSummarizer::SummarizationService do
       described_class.enqueue_for(discussion_topic: topic, viewer:)
     end
 
-    it "chains #summarize on the delay proxy with the correct discussion_topic and viewer kwargs" do
+    it "chains #fetch_or_create_summary on the delay proxy with the correct discussion_topic and viewer kwargs" do
       expect_any_instance_of(described_class).to receive(:delay).and_return(delay_proxy)
-      expect(delay_proxy).to receive(:summarize).with(discussion_topic: topic, viewer:)
+      expect(delay_proxy).to receive(:fetch_or_create_summary).with(discussion_topic: topic, viewer:)
 
       described_class.enqueue_for(discussion_topic: topic, viewer:)
     end
@@ -459,5 +459,128 @@ describe DiscussionThreadSummarizer::SummarizationService do
       expect(capturing_client.received_payloads.first)
         .to eq(capturing_client.received_payloads.last)
     end
+  end
+
+end
+
+# DB-backed cache tests (Cycle 16, #16) — separate describe to avoid instance_double stubs.
+describe "DiscussionThreadSummarizer::SummarizationService#fetch_or_create_summary" do
+  let(:course)         { course_model }
+  let(:user)           { user_model }
+  let(:topic)          { course.discussion_topics.create! }
+  let(:viewer)         { user }
+  let(:locale)         { "en" }
+  let(:stub_client)    { DiscussionThreadSummarizer::StubModelClient.new }
+  let(:service)        { DiscussionThreadSummarizer::SummarizationService.new(client: stub_client) }
+  let(:content_hash)   { DiscussionThreadSummarizer::ContentVersionHash.call(topic) }
+
+  before do
+    topic.discussion_entries.create!(user:, message: "hello")
+    allow(Rails.logger).to receive(:info)
+  end
+
+  def seed_summary(locale: "en", hash: content_hash, summary_json: nil)
+    topic.summaries.create!(
+      user:,
+      locale:,
+      summary: summary_json || DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE.to_json,
+      dynamic_content_hash: hash,
+      llm_config_version: DiscussionThreadSummarizer::SummarizationService::LLM_CONFIG_VERSION
+    )
+  end
+
+  it "returns :hit without calling the model client when a matching row exists" do
+    seed_summary
+    allow(stub_client).to receive(:summarize).and_call_original
+
+    result = service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+    expect(result.status).to eq(:hit)
+    expect(stub_client).not_to have_received(:summarize)
+  end
+
+  it "returns :miss, calls the client once, and creates one DiscussionTopicSummary" do
+    allow(stub_client).to receive(:summarize).and_call_original
+
+    expect do
+      result = service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+      expect(result.status).to eq(:miss)
+    end.to change { topic.summaries.count }.by(1)
+
+    expect(stub_client).to have_received(:summarize).once
+  end
+
+  it "miss-then-hit calls the model client only once" do
+    allow(stub_client).to receive(:summarize).and_call_original
+
+    service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+    service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+    expect(stub_client).to have_received(:summarize).once
+  end
+
+  it "isolates cache rows per discussion topic" do
+    topic_b = course.discussion_topics.create!
+    topic_b.discussion_entries.create!(user:, message: "other thread")
+    allow(stub_client).to receive(:summarize).and_call_original
+
+    service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+    service.fetch_or_create_summary(discussion_topic: topic_b, viewer:, locale:)
+
+    expect(topic.summaries.count).to eq(1)
+    expect(topic_b.summaries.count).to eq(1)
+    expect(stub_client).to have_received(:summarize).twice
+  end
+
+  it "stores separate rows per locale for the same topic content" do
+    seed_summary(locale: "en")
+    allow(stub_client).to receive(:summarize).and_call_original
+
+    service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale: "es")
+
+    expect(topic.summaries.pluck(:locale)).to contain_exactly("en", "es")
+    expect(stub_client).to have_received(:summarize).once
+  end
+
+  it "persists dynamic_content_hash equal to ContentVersionHash.call(topic)" do
+    allow(stub_client).to receive(:summarize).and_call_original
+
+    service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+    expect(topic.summaries.last.dynamic_content_hash).to eq(content_hash)
+  end
+
+  it "returns identical :result on miss-then-hit (parsed DB JSON matches pipeline output)" do
+    allow(stub_client).to receive(:summarize).and_call_original
+
+    miss = service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+    hit  = service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+    expect(hit.result).to eq(miss.result)
+    expect(hit.result).to eq(DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE)
+  end
+
+  it "emits cache.hit when serving a cached summary" do
+    seed_summary
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_cache_hit)
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_cache_miss)
+
+    service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+    expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_cache_hit)
+      .with(account: course.root_account)
+    expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_cache_miss)
+  end
+
+  it "emits cache.miss when no cached summary exists" do
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_cache_miss)
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_cache_hit)
+    allow(stub_client).to receive(:summarize).and_call_original
+
+    service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+    expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_cache_miss)
+      .with(account: course.root_account)
+    expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_cache_hit)
   end
 end


### PR DESCRIPTION
## Summary

Adds cache read/write to `DiscussionThreadSummarizer::SummarizationService` via `fetch_or_create_summary`, mirroring `DiscussionTopicsApiController#fetch_or_create_summary` tuple lookup.

## Changes

- `LLM_CONFIG_VERSION = "thread-summarizer-v1"` and `CacheResult` struct
- `fetch_or_create_summary(discussion_topic:, viewer:, locale:)` — O(1) lookup on `(llm_config_version, dynamic_content_hash, parent_id, locale)`; stores `ContentVersionHash` output directly
- `enqueue_for` dispatches `fetch_or_create_summary` (same kwargs)
- `cache.hit` / `cache.miss` metrics at service boundary
- Scope-limited cache caveat comment → [#85](https://github.com/ejgdr/canvas-lms/issues/85)

## Tests

38 examples, 0 failures (seed 60703, ~13.6s)

## Scope

- Closes narrowed [#16](https://github.com/ejgdr/canvas-lms/issues/16) (pipeline only)
- Does **not** close [#84](https://github.com/ejgdr/canvas-lms/issues/84) (render path)

closes #16
flag=none