### PR TITLE
[M3] Cache invalidation hooks + meaningful-change threshold (closes #17)

### DIFF
--- a/app/models/discussion_entry.rb
+++ b/app/models/discussion_entry.rb
@@ -67,6 +67,7 @@ class DiscussionEntry < ApplicationRecord
   after_create :log_discussion_entry_metrics
   after_create :clear_planner_cache_for_participants
   after_create :update_topic
+  after_create :schedule_thread_summary_cache_invalidation_on_create
   after_destroy :remove_pin
   after_save :update_discussion
   after_save :context_module_action_later
@@ -266,8 +267,40 @@ class DiscussionEntry < ApplicationRecord
         dt = dt.root_topic
         break if dt.blank?
       end
-      self.class.connection.after_transaction_commit { discussion_topic.update_materialized_view }
+      self.class.connection.after_transaction_commit do
+        discussion_topic.update_materialized_view
+        consider_thread_summary_cache_invalidation
+      end
     end
+  end
+
+  def schedule_thread_summary_cache_invalidation_on_create
+    return unless workflow_state == "active"
+    return unless thread_summarizer_enabled?
+
+    self.class.connection.after_transaction_commit do
+      DiscussionThreadSummarizer::CacheInvalidation.handle_entry_created(self)
+    end
+  end
+
+  def consider_thread_summary_cache_invalidation
+    return unless thread_summarizer_enabled?
+
+    if saved_change_to_workflow_state? && workflow_state == "deleted"
+      DiscussionThreadSummarizer::CacheInvalidation.handle_entry_deleted(self)
+    elsif saved_change_to_message? && !previously_new_record? && workflow_state == "active"
+      message_before, message_after = saved_change_to_message
+      DiscussionThreadSummarizer::CacheInvalidation.handle_entry_updated(
+        self,
+        message_before:,
+        message_after:
+      )
+    end
+  end
+
+  def thread_summarizer_enabled?
+    course = discussion_topic&.context
+    course.is_a?(Course) && course.feature_enabled?(:discussion_thread_summarizer)
   end
 
   def create_discussion_entry_versions

--- a/app/services/discussion_thread_summarizer/cache_invalidation.rb
+++ b/app/services/discussion_thread_summarizer/cache_invalidation.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module DiscussionThreadSummarizer
+  # Write-side cache invalidation for DiscussionTopicSummary rows.
+  # Meaningful changes leave rows as hash orphans (stale-aware lookup in #84).
+  # Below-threshold message edits rekey dynamic_content_hash without regeneration.
+  class CacheInvalidation
+    SETTING_KEY = "discussion_thread_summarizer_meaningful_change_word_threshold"
+    DEFAULT_WORD_THRESHOLD = 5
+
+    def self.handle_entry_created(entry)
+      new(entry).handle_created
+    end
+
+    def self.handle_entry_updated(entry, message_before:, message_after:)
+      new(entry).handle_updated(message_before:, message_after:)
+    end
+
+    def self.handle_entry_deleted(entry)
+      new(entry).handle_deleted
+    end
+
+    def initialize(entry)
+      @entry = entry
+      @topic = entry.discussion_topic
+    end
+
+    def handle_created
+      return unless enabled?
+
+      Metrics.increment_invalidation_fired(cause: "create", account:)
+    end
+
+    def handle_deleted
+      return unless enabled?
+
+      Metrics.increment_invalidation_fired(cause: "delete", account:)
+    end
+
+    def handle_updated(message_before:, message_after:)
+      return unless enabled?
+
+      delta = word_delta(message_before, message_after)
+      if delta < word_threshold
+        rekey_summaries
+        Metrics.increment_invalidation_skipped_below_threshold(account:)
+      else
+        Metrics.increment_invalidation_fired(cause: "edit", account:)
+      end
+    end
+
+    private
+
+    def enabled?
+      course = @topic&.context
+      course.is_a?(Course) && course.feature_enabled?(:discussion_thread_summarizer)
+    end
+
+    def account
+      @topic.context.root_account
+    end
+
+    def word_threshold
+      Setting.get(SETTING_KEY, DEFAULT_WORD_THRESHOLD.to_s).to_i
+    end
+
+    def word_delta(before, after)
+      count = ->(msg) { HtmlTextHelper.strip_tags(msg.to_s).split.size }
+      (count.call(after) - count.call(before)).abs
+    end
+
+    def rekey_summaries
+      new_hash = ContentVersionHash.call(@topic)
+      # NOTE: Rekey updates dynamic_content_hash to the post-edit content hash
+      # even though the stored summary text was generated from the pre-edit content.
+      # This is the intended behavior per #17 AC: below-threshold edits do not
+      # trigger regeneration. The hash semantically means "the content this summary
+      # is considered current for", not "the content this summary was generated from".
+      # See https://github.com/ejgdr/canvas-lms/issues/17 for the threshold definition.
+      @topic.summaries
+            .where(
+              llm_config_version: SummarizationService::LLM_CONFIG_VERSION,
+              parent_id: nil
+            )
+            .update_all(dynamic_content_hash: new_hash, updated_at: Time.current)
+    end
+  end
+end

--- a/lib/discussion_thread_summarizer/metrics.rb
+++ b/lib/discussion_thread_summarizer/metrics.rb
@@ -71,6 +71,23 @@ module DiscussionThreadSummarizer
       )
     end
 
+    # Emitted when a meaningful entry change orphans cached summaries (hash mismatch).
+    # cause: one of "create", "edit", "delete"
+    def self.increment_invalidation_fired(cause:, account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.invalidation.fired",
+        tags: { account_id: account.global_id, cause: }
+      )
+    end
+
+    # Emitted when a below-threshold message edit rekeys rows without invalidation.
+    def self.increment_invalidation_skipped_below_threshold(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.invalidation.skipped_below_threshold",
+        tags: { account_id: account.global_id }
+      )
+    end
+
     # Emitted when a user submits an inaccuracy report against a summary.
     # reason_category: one of "inaccurate", "missed_viewpoint",
     #                  "harmful_content", "other"

--- a/spec/lib/discussion_thread_summarizer/metrics_spec.rb
+++ b/spec/lib/discussion_thread_summarizer/metrics_spec.rb
@@ -76,6 +76,26 @@ describe DiscussionThreadSummarizer::Metrics do
     end
   end
 
+  describe ".increment_invalidation_fired" do
+    it "emits discussion_thread_summarizer.invalidation.fired with account_id and cause tags" do
+      described_class.increment_invalidation_fired(cause: "edit", account:)
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.invalidation.fired",
+        tags: { account_id: 10_000_000_000_001, cause: "edit" }
+      )
+    end
+  end
+
+  describe ".increment_invalidation_skipped_below_threshold" do
+    it "emits discussion_thread_summarizer.invalidation.skipped_below_threshold with account_id tag" do
+      described_class.increment_invalidation_skipped_below_threshold(account:)
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.invalidation.skipped_below_threshold",
+        tags: { account_id: 10_000_000_000_001 }
+      )
+    end
+  end
+
   describe ".increment_report_submission" do
     it "emits discussion_thread_summarizer.report.submission with account_id, reason_category, and reporter_role tags" do
       described_class.increment_report_submission(

--- a/spec/services/discussion_thread_summarizer/cache_invalidation_spec.rb
+++ b/spec/services/discussion_thread_summarizer/cache_invalidation_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+describe DiscussionThreadSummarizer::CacheInvalidation do
+  let(:course)  { course_model }
+  let(:user)    { user_model }
+  let(:topic)   { course.discussion_topics.create! }
+  let(:account) { course.root_account }
+  let(:entry)   { topic.discussion_entries.create!(user:, message: "one two three four five six seven") }
+  let(:llm_version) { DiscussionThreadSummarizer::SummarizationService::LLM_CONFIG_VERSION }
+
+  before do
+    course.enable_feature!(:discussion_thread_summarizer)
+    allow(InstStatsd::Statsd).to receive(:distributed_increment)
+    allow_any_instance_of(DiscussionTopic).to receive(:update_materialized_view)
+    allow_any_instance_of(DiscussionEntry).to receive(:schedule_thread_summary_cache_invalidation_on_create)
+    allow_any_instance_of(DiscussionEntry).to receive(:consider_thread_summary_cache_invalidation)
+  end
+
+  def seed_summary(locale: "en", hash:)
+    topic.summaries.create!(
+      user:,
+      locale:,
+      summary: DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE.to_json,
+      dynamic_content_hash: hash,
+      llm_config_version: llm_version
+    )
+  end
+
+  def fired_metric(cause:)
+    [
+      "discussion_thread_summarizer.invalidation.fired",
+      { tags: { account_id: account.global_id, cause: } }
+    ]
+  end
+
+  def skipped_metric
+    [
+      "discussion_thread_summarizer.invalidation.skipped_below_threshold",
+      { tags: { account_id: account.global_id } }
+    ]
+  end
+
+  it "fires invalidation.fired cause create on handle_entry_created" do
+    described_class.handle_entry_created(entry)
+    expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(*fired_metric(cause: "create"))
+    expect(InstStatsd::Statsd).not_to have_received(:distributed_increment).with(*skipped_metric)
+  end
+
+  it "fires invalidation.fired cause edit and preserves stale hash on above-threshold edit" do
+    stale_hash = "0" * 64
+    seed_summary(hash: stale_hash)
+    after_msg = "one two three four five six seven eight nine ten eleven twelve"
+    described_class.handle_entry_updated(entry, message_before: entry.message, message_after: after_msg)
+    expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(*fired_metric(cause: "edit")).once
+    expect(topic.summaries.pluck(:dynamic_content_hash)).to eq([stale_hash])
+  end
+
+  it "skips invalidation and rekeys rows on below-threshold edit" do
+    seed_summary(hash: "0" * 64)
+    after_msg = "one two three four five six seven."
+    before_msg = entry.message
+    entry.update_column(:message, after_msg)
+    described_class.handle_entry_updated(entry, message_before: before_msg, message_after: after_msg)
+    expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(*skipped_metric).once
+    expect(InstStatsd::Statsd).not_to have_received(:distributed_increment).with(*fired_metric(cause: "edit"))
+    expect(topic.summaries.pluck(:dynamic_content_hash).uniq).to eq(
+      [DiscussionThreadSummarizer::ContentVersionHash.call(topic)]
+    )
+  end
+
+  it "fires invalidation.fired cause delete on handle_entry_deleted" do
+    described_class.handle_entry_deleted(entry)
+    expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(*fired_metric(cause: "delete"))
+  end
+
+  it "does not route editor_id-only saves through invalidation handlers" do
+    entry
+    allow(entry).to receive(:consider_thread_summary_cache_invalidation).and_call_original
+    expect(described_class).not_to receive(:handle_entry_updated)
+    expect(described_class).not_to receive(:handle_entry_deleted)
+    entry.update!(editor_id: user.id)
+    entry.consider_thread_summary_cache_invalidation
+  end
+
+  it "emits no metrics and does not rekey when the feature flag is off" do
+    seed_summary(hash: "0" * 64)
+    allow_any_instance_of(described_class).to receive(:enabled?).and_return(false)
+    allow(InstStatsd::Statsd).to receive(:distributed_increment)
+    described_class.handle_entry_updated(
+      entry,
+      message_before: entry.message,
+      message_after: "one two three four five six seven."
+    )
+    expect(InstStatsd::Statsd).not_to have_received(:distributed_increment).with(
+      a_string_starting_with("discussion_thread_summarizer.invalidation"),
+      anything
+    )
+    expect(topic.summaries.pluck(:dynamic_content_hash)).to eq(["0" * 64])
+  end
+
+  it "still returns cache :hit after below-threshold rekey" do
+    seed_summary(hash: DiscussionThreadSummarizer::ContentVersionHash.call(topic))
+    stub_client = DiscussionThreadSummarizer::StubModelClient.new
+    service = DiscussionThreadSummarizer::SummarizationService.new(client: stub_client)
+    allow(stub_client).to receive(:summarize).and_call_original
+    after_msg = "one two three four five six seven."
+    before_msg = entry.message
+    entry.update_column(:message, after_msg)
+    described_class.handle_entry_updated(entry, message_before: before_msg, message_after: after_msg)
+    result = service.fetch_or_create_summary(discussion_topic: topic, viewer: user, locale: "en")
+    expect(result.status).to eq(:hit)
+    expect(stub_client).not_to have_received(:summarize)
+  end
+
+  it "uses soft-delete on normal destroy (user delete path)" do
+    entry.destroy
+    expect(entry.reload.workflow_state).to eq("deleted")
+  end
+
+  it "does not call the model client or enqueue jobs on below-threshold rekey" do
+    seed_summary(hash: "0" * 64)
+    stub_client = DiscussionThreadSummarizer::StubModelClient.new
+    allow(stub_client).to receive(:summarize).and_call_original
+    service = DiscussionThreadSummarizer::SummarizationService.new(client: stub_client)
+    after_msg = "one two three four five six seven."
+    before_msg = entry.message
+    entry.update_column(:message, after_msg)
+    jobs_before = Delayed::Job.count
+    described_class.handle_entry_updated(entry, message_before: before_msg, message_after: after_msg)
+    service.fetch_or_create_summary(discussion_topic: topic, viewer: user, locale: "en")
+    expect(Delayed::Job.count).to eq(jobs_before)
+    expect(stub_client).not_to have_received(:summarize)
+  end
+
+  it "rekeys all locale rows to the same post-edit hash in one operation" do
+    old_hash = "1" * 64
+    %w[en es fr].each { |locale| seed_summary(locale:, hash: old_hash) }
+    after_msg = "one two three four five six seven."
+    before_msg = entry.message
+    entry.update_column(:message, after_msg)
+    described_class.handle_entry_updated(entry, message_before: before_msg, message_after: after_msg)
+    new_hash = DiscussionThreadSummarizer::ContentVersionHash.call(topic)
+    expect(topic.summaries.pluck(:dynamic_content_hash).uniq).to eq([new_hash])
+  end
+end


### PR DESCRIPTION
## Summary
- Add `DiscussionThreadSummarizer::CacheInvalidation` for write-side cache invalidation on entry create, edit, and soft-delete
- Meaningful changes (create, delete, edit with word delta ≥ threshold) emit `invalidation.fired` and leave summary rows as hash orphans
- Below-threshold edits rekey `dynamic_content_hash` via `update_all` without regeneration

Closes #17

## Test plan
- [x] `docker compose exec web bundle exec rspec spec/services/discussion_thread_summarizer/cache_invalidation_spec.rb spec/lib/discussion_thread_summarizer/metrics_spec.rb`
- [x] 18 examples, 0 failures (seed 43247)

## Tripwires
- No `ContentVersionHash` edits
- No `#fetch_or_create_summary` signature or cache tuple changes
- No new feature flags
- Diff: **339 lines** (impl ~158 + spec ~181) — exceeds 250 target; rekey comment + 10 spec examples drive overage

flag=none