### PR TITLE
[M3] Regeneration rate limiter (closes #18)

### DIFF
--- a/app/services/discussion_thread_summarizer/regeneration_rate_limiter.rb
+++ b/app/services/discussion_thread_summarizer/regeneration_rate_limiter.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+module DiscussionThreadSummarizer
+  # Redis-backed regeneration gate: per-user per-thread cooldown + per-account daily quota.
+  class RegenerationRateLimiter
+    COOLDOWN_SETTING_KEY = "discussion_thread_summarizer_user_thread_cooldown_seconds"
+    DEFAULT_COOLDOWN_SECONDS = "600"
+    QUOTA_SETTING_KEY = "discussion_thread_summarizer_account_daily_quota"
+    DEFAULT_DAILY_QUOTA = "100"
+    REDIS_REQUIRED_MESSAGE =
+      "InstLLMHelper rate limiting requires Redis to be enabled for the Canvas instance. " \
+      "You may remove the 'rate_limit' option from the LLMConfig to disable rate limiting."
+
+    def self.check(account:, user:, discussion_topic:)
+      course = discussion_topic.context
+      return :allowed unless course.is_a?(Course) && course.feature_enabled?(:discussion_thread_summarizer)
+
+      raise REDIS_REQUIRED_MESSAGE unless Canvas.redis_enabled?
+
+      unless acquire_cooldown(user:, discussion_topic:)
+        return :cooldown_denied
+      end
+
+      return :quota_denied unless acquire_quota(account:)
+
+      :allowed
+    end
+
+    def self.acquire_cooldown(user:, discussion_topic:)
+      seconds = Setting.get(COOLDOWN_SETTING_KEY, DEFAULT_COOLDOWN_SECONDS).to_i
+      Canvas.redis.set(cooldown_key(user, discussion_topic), 1, nx: true, ex: seconds)
+    end
+    private_class_method :acquire_cooldown
+
+    def self.acquire_quota(account:)
+      limit = Setting.get(QUOTA_SETTING_KEY, DEFAULT_DAILY_QUOTA).to_i
+      key = quota_key(account)
+      count = Canvas.redis.incr(key).to_i
+      Canvas.redis.expire(key, 24.hours.to_i) if count == 1
+
+      if count > limit
+        Canvas.redis.decr(key)
+        return false
+      end
+
+      true
+    end
+    private_class_method :acquire_quota
+
+    def self.cooldown_key(user, discussion_topic)
+      ["discussion_thread_summarizer", "cooldown", user.id, discussion_topic.id].cache_key
+    end
+    private_class_method :cooldown_key
+
+    def self.quota_key(account)
+      ["discussion_thread_summarizer", "quota", account.global_id, Time.now.utc.strftime("%Y%m%d")].cache_key
+    end
+    private_class_method :quota_key
+  end
+end

--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -61,6 +61,25 @@ module DiscussionThreadSummarizer
       end
 
       DiscussionThreadSummarizer::Metrics.increment_cache_miss(account:)
+
+      # NOTE: The rekey path in DiscussionThreadSummarizer::CacheInvalidation does NOT
+      # pass through this gate — rekey is a metadata-only UPDATE that never invokes the
+      # model, so it must not consume cooldown or daily-quota budget. The limiter is
+      # only consulted on the cache-miss path of #fetch_or_create_summary, immediately
+      # before #summarize. Cache hits also bypass the limiter (no model call).
+      #
+      # Redis-down posture: fail-closed — matches InstLLMHelper behavior verified at
+      # app/helpers/inst_llm_helper.rb:41 during Cycle 18 (raises when Redis disabled).
+      case RegenerationRateLimiter.check(account:, user: viewer, discussion_topic:)
+      when :cooldown_denied
+        DiscussionThreadSummarizer::Metrics.increment_rate_limit_cooldown_denied(account:)
+        return CacheResult.new(status: :rate_limited, record: nil, result: nil)
+      when :quota_denied
+        DiscussionThreadSummarizer::Metrics.increment_rate_limit_quota_denied(account:)
+        return CacheResult.new(status: :rate_limited, record: nil, result: nil)
+      end
+
+      DiscussionThreadSummarizer::Metrics.increment_rate_limit_allowed(account:)
       result = summarize(discussion_topic:, viewer:)
       record = persist_summary_record(
         discussion_topic:,

--- a/lib/discussion_thread_summarizer/metrics.rb
+++ b/lib/discussion_thread_summarizer/metrics.rb
@@ -88,6 +88,30 @@ module DiscussionThreadSummarizer
       )
     end
 
+    # Emitted when regeneration is allowed (cooldown and quota checks passed).
+    def self.increment_rate_limit_allowed(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.rate_limit.allowed",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Emitted when per-user per-thread cooldown denies regeneration.
+    def self.increment_rate_limit_cooldown_denied(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.rate_limit.cooldown_denied",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Emitted when per-account daily quota denies regeneration.
+    def self.increment_rate_limit_quota_denied(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.rate_limit.quota_denied",
+        tags: { account_id: account.global_id }
+      )
+    end
+
     # Emitted when a user submits an inaccuracy report against a summary.
     # reason_category: one of "inaccurate", "missed_viewpoint",
     #                  "harmful_content", "other"

--- a/spec/services/discussion_thread_summarizer/regeneration_rate_limiter_spec.rb
+++ b/spec/services/discussion_thread_summarizer/regeneration_rate_limiter_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+describe DiscussionThreadSummarizer::RegenerationRateLimiter do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:course)  { course_model }
+  let(:user)    { user_model }
+  let(:topic)   { course.discussion_topics.create! }
+  let(:account) { course.root_account }
+
+  before do
+    allow(Canvas).to receive(:redis_enabled?).and_return(true)
+    course.enable_feature!(:discussion_thread_summarizer)
+  end
+
+  def cooldown_key(for_user: user, for_topic: topic)
+    ["discussion_thread_summarizer", "cooldown", for_user.id, for_topic.id].cache_key
+  end
+
+  def quota_key(for_account: account, day: Time.now.utc.strftime("%Y%m%d"))
+    ["discussion_thread_summarizer", "quota", for_account.global_id, day].cache_key
+  end
+
+  it "denies the second miss for the same user and thread within cooldown" do
+    allow(Canvas.redis).to receive(:set).with(cooldown_key, 1, nx: true, ex: 600).and_return(true, false)
+    allow(Canvas.redis).to receive(:incr).and_return(1)
+    allow(Canvas.redis).to receive(:expire)
+
+    expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:allowed)
+    expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:cooldown_denied)
+  end
+
+  it "allows two threads for the same user when cooldown keys differ" do
+    topic_b = course.discussion_topics.create!
+    allow(Canvas.redis).to receive(:set).with(cooldown_key, 1, nx: true, ex: 600).and_return(true)
+    allow(Canvas.redis).to receive(:set).with(cooldown_key(for_topic: topic_b), 1, nx: true, ex: 600).and_return(true)
+    allow(Canvas.redis).to receive(:incr).and_return(1, 2)
+    allow(Canvas.redis).to receive(:expire)
+
+    expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:allowed)
+    expect(described_class.check(account:, user:, discussion_topic: topic_b)).to eq(:allowed)
+  end
+
+  it "allows two users on the same thread when cooldown keys differ" do
+    user_b = user_model
+    allow(Canvas.redis).to receive(:set).with(cooldown_key, 1, nx: true, ex: 600).and_return(true)
+    allow(Canvas.redis).to receive(:set).with(cooldown_key(for_user: user_b), 1, nx: true, ex: 600).and_return(true)
+    allow(Canvas.redis).to receive(:incr).and_return(1, 2)
+    allow(Canvas.redis).to receive(:expire)
+
+    expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:allowed)
+    expect(described_class.check(account:, user: user_b, discussion_topic: topic)).to eq(:allowed)
+  end
+
+  it "denies when daily quota is exceeded and rolls back the increment" do
+    allow(Canvas.redis).to receive(:set).and_return(true)
+    allow(Canvas.redis).to receive(:incr).with(quota_key).and_return(101)
+    expect(Canvas.redis).to receive(:decr).with(quota_key)
+
+    expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:quota_denied)
+  end
+
+  it "allows regeneration after cooldown TTL elapses" do
+    travel_to Time.utc(2026, 1, 15, 12, 0, 0) do
+      allow(Canvas.redis).to receive(:set).and_return(true, true)
+      allow(Canvas.redis).to receive(:incr).and_return(1, 2)
+      allow(Canvas.redis).to receive(:expire)
+
+      expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:allowed)
+      travel 601.seconds
+      expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:allowed)
+    end
+  end
+
+  it "resets daily quota at the UTC day boundary" do
+    travel_to Time.utc(2026, 1, 15, 23, 30, 0) do
+      key_day_one = quota_key(day: "20260115")
+      allow(Canvas.redis).to receive(:set).and_return(true)
+      allow(Canvas.redis).to receive(:incr).with(key_day_one).and_return(100)
+      allow(Canvas.redis).to receive(:expire)
+
+      expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:allowed)
+    end
+
+    travel_to Time.utc(2026, 1, 16, 0, 0, 1) do
+      key_day_two = quota_key(day: "20260116")
+      allow(Canvas.redis).to receive(:set).and_return(true)
+      allow(Canvas.redis).to receive(:incr).with(key_day_two).and_return(1)
+      allow(Canvas.redis).to receive(:expire)
+
+      expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:allowed)
+    end
+  end
+
+  it "does not touch Redis during CacheInvalidation rekey" do
+    allow_any_instance_of(DiscussionTopic).to receive(:update_materialized_view)
+    allow_any_instance_of(DiscussionEntry).to receive(:schedule_thread_summary_cache_invalidation_on_create)
+    allow_any_instance_of(DiscussionEntry).to receive(:consider_thread_summary_cache_invalidation)
+    entry = topic.discussion_entries.create!(user:, message: "one two three four five six seven")
+    seed_hash = "0" * 64
+    topic.summaries.create!(
+      user:,
+      locale: "en",
+      summary: DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE.to_json,
+      dynamic_content_hash: seed_hash,
+      llm_config_version: DiscussionThreadSummarizer::SummarizationService::LLM_CONFIG_VERSION
+    )
+    allow(Canvas.redis).to receive(:set)
+    allow(Canvas.redis).to receive(:incr)
+
+    DiscussionThreadSummarizer::CacheInvalidation.handle_entry_updated(
+      entry,
+      message_before: entry.message,
+      message_after: "one two three four five six seven."
+    )
+
+    expect(Canvas.redis).not_to have_received(:set)
+    expect(Canvas.redis).not_to have_received(:incr)
+  end
+
+  it "returns :allowed without Redis when the feature flag is off" do
+    course.disable_feature!(:discussion_thread_summarizer)
+    expect(Canvas.redis).not_to receive(:set)
+    expect(Canvas.redis).not_to receive(:incr)
+
+    expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:allowed)
+  end
+
+  # SET NX is atomic at Redis; concurrent allow-check race is not testable at the Ruby layer.
+  it "skips concurrent race coverage (SET NX is atomic at Redis)" do
+    skip "SET NX is atomic at Redis; concurrent allow-check race is not testable at the Ruby layer"
+  end
+
+  it "checks cooldown before quota and does not INCR when cooldown denies" do
+    allow(Canvas.redis).to receive(:set).and_return(false)
+    expect(Canvas.redis).not_to receive(:incr)
+
+    expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:cooldown_denied)
+  end
+
+  it "restores quota counter after deny so a subsequent check at the limit can allow" do
+    allow(Canvas.redis).to receive(:set).and_return(true)
+    allow(Canvas.redis).to receive(:incr).with(quota_key).and_return(101, 100)
+    expect(Canvas.redis).to receive(:decr).with(quota_key).once
+    allow(Canvas.redis).to receive(:expire)
+
+    expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:quota_denied)
+    expect(described_class.check(account:, user:, discussion_topic: topic)).to eq(:allowed)
+  end
+
+  it "raises when Redis is disabled (fail-closed, matches InstLLMHelper)" do
+    allow(Canvas).to receive(:redis_enabled?).and_return(false)
+    expect do
+      described_class.check(account:, user:, discussion_topic: topic)
+    end.to raise_error(
+      "InstLLMHelper rate limiting requires Redis to be enabled for the Canvas instance. " \
+      "You may remove the 'rate_limit' option from the LLMConfig to disable rate limiting."
+    )
+  end
+end

--- a/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
+++ b/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
@@ -583,4 +583,53 @@ describe "DiscussionThreadSummarizer::SummarizationService#fetch_or_create_summa
       .with(account: course.root_account)
     expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_cache_hit)
   end
+
+  context "regeneration rate limiter (Cycle 18)" do
+    before do
+      course.enable_feature!(:discussion_thread_summarizer)
+      allow(Canvas).to receive(:redis_enabled?).and_return(true)
+    end
+
+    it "returns :rate_limited on cooldown deny without calling the model" do
+      allow(DiscussionThreadSummarizer::RegenerationRateLimiter).to receive(:check)
+        .and_return(:cooldown_denied)
+      allow(stub_client).to receive(:summarize).and_call_original
+      allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_rate_limit_cooldown_denied)
+
+      result = service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+      expect(result.status).to eq(:rate_limited)
+      expect(result.record).to be_nil
+      expect(result.result).to be_nil
+      expect(stub_client).not_to have_received(:summarize)
+      expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_rate_limit_cooldown_denied)
+        .with(account: course.root_account)
+    end
+
+    it "returns :rate_limited on quota deny without persisting a summary row" do
+      allow(DiscussionThreadSummarizer::RegenerationRateLimiter).to receive(:check)
+        .and_return(:quota_denied)
+      allow(stub_client).to receive(:summarize).and_call_original
+      allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_rate_limit_quota_denied)
+
+      expect do
+        result = service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+        expect(result.status).to eq(:rate_limited)
+      end.not_to change { topic.summaries.count }
+
+      expect(stub_client).not_to have_received(:summarize)
+    end
+
+    it "emits rate_limit.allowed and summarizes when the limiter allows" do
+      allow(DiscussionThreadSummarizer::RegenerationRateLimiter).to receive(:check).and_return(:allowed)
+      allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_rate_limit_allowed)
+      allow(stub_client).to receive(:summarize).and_call_original
+
+      service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+      expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_rate_limit_allowed)
+        .with(account: course.root_account)
+      expect(stub_client).to have_received(:summarize).once
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `DiscussionThreadSummarizer::RegenerationRateLimiter` (per-user/thread cooldown via `SET NX EX`, per-account daily quota via `INCR` + rollback on deny).
- Gate `SummarizationService#fetch_or_create_summary` cache-miss path immediately before `#summarize`; deny returns `CacheResult` with `status: :rate_limited`, `record: nil`, `result: nil`.
- Emit `rate_limit.allowed`, `rate_limit.cooldown_denied`, and `rate_limit.quota_denied` metrics.

## Diff overage acknowledgment

**Diff:** +347 combined lines (impl 121 + spec 226). Over the 250 soft cap by ~39%. Spec overrun on `regeneration_rate_limiter_spec.rb` (177 vs estimated 110) and `summarization_service_spec.rb` integration examples (49 vs estimated 25). Surfaced per cycle convention rather than absorbed silently. Spec coverage is intentional (10 unit + 3 integration + 1 documented skip) and includes the rekey-bypass invariant assertion required by the contract with Cycle 17.

## Prerequisites (Cycle 18)
- **InstLLMHelper Redis-down posture (verbatim):** At `app/helpers/inst_llm_helper.rb:41`, when rate limiting applies and `!Canvas.redis_enabled?`, Canvas **raises** (fail-closed) — it does not allow-with-warn. `RegenerationRateLimiter` matches this posture.
- **#18 re-scoped:** Pipeline-only deny contract; user-visible stale/rate-limited rendering → #84; admin override → #23.

## Contract change (only post–Cycle-16)
- `CacheResult.status` extended with `:rate_limited` (kwargs unchanged).

## Test plan
- [x] `bin/rspec spec/services/discussion_thread_summarizer/regeneration_rate_limiter_spec.rb`
- [x] `bin/rspec spec/services/discussion_thread_summarizer/summarization_service_spec.rb` (rate limit context)
- RSpec seeds: `1`, `13659`, `511` — 50 examples, 0 failures, 1 skipped (stability confirmed across multiple seeds)

Closes #18