### PR TITLE
[M3] Render lookup + preview + GET endpoint (closes #84)

### DIFF
--- a/app/controllers/discussion_topics_api_controller.rb
+++ b/app/controllers/discussion_topics_api_controller.rb
@@ -137,6 +137,25 @@ class DiscussionTopicsApiController < ApplicationController
     render(json: { id: summary.id, text: summary.summary, userInput: summary.user_input, obsolete: summary_obsolete, usage: { currentCount: current_count, limit: } })
   end
 
+  # @API Thread summary render status (Discussion Thread Summarizer)
+  #
+  # Read-only lookup for per-thread summary render state. Does not block on
+  # generation; enqueues a background job when status is stale or generating.
+  #
+  # @example_request
+  #
+  #     curl https://<canvas>/api/v1/courses/<course_id>/discussion_topics/<topic_id>/thread_summary \
+  #         -H 'Authorization: Bearer <token>'
+  def thread_summary
+    result = DiscussionThreadSummarizer::SummarizationService.new.lookup_for_render(
+      discussion_topic: @topic,
+      viewer: @current_user,
+      locale: I18n.locale.to_s
+    )
+
+    render(json: thread_summary_json(result))
+  end
+
   # @API Find or Create Summary
   #
   # Generates a summary for a discussion topic. Returns the summary text and usage information.
@@ -1343,6 +1362,20 @@ class DiscussionTopicsApiController < ApplicationController
     }
 
     { content: refined_dynamic_content, hash: Digest::SHA256.hexdigest(refined_dynamic_content.to_json) }
+  end
+
+  def thread_summary_json(result)
+    if result.status == :disabled
+      return { status: "disabled", enabled: false, enqueued: false }
+    end
+
+    {
+      status: result.status.to_s,
+      enabled: true,
+      enqueued: result.enqueued,
+      summary: result.result,
+      record_id: result.record&.id
+    }
   end
 
   def fetch_or_create_summary(llm_config:, dynamic_content:, dynamic_content_hash:, user_input:, parent_summary: nil, locale: nil)

--- a/app/services/discussion_thread_summarizer/regeneration_rate_limiter.rb
+++ b/app/services/discussion_thread_summarizer/regeneration_rate_limiter.rb
@@ -44,6 +44,26 @@ module DiscussionThreadSummarizer
       :allowed
     end
 
+    # READ-ONLY probe. Mirrors .check's cooldown-before-quota ordering using GET
+    # on the cooldown key and quota counter. Does NOT mutate Redis — no SET, no
+    # INCR, no DECR, no EXPIRE. Intended for render-time decisions where
+    # consuming budget would be incorrect (the generation worker calls .check).
+    def self.preview(account:, user:, discussion_topic:)
+      course = discussion_topic.context
+      return :allowed unless course.is_a?(Course) && course.feature_enabled?(:discussion_thread_summarizer)
+
+      raise REDIS_REQUIRED_MESSAGE unless Canvas.redis_enabled?
+
+      if Canvas.redis.get(cooldown_key(user, discussion_topic)).present?
+        return :cooldown_denied
+      end
+
+      limit = Setting.get(QUOTA_SETTING_KEY, DEFAULT_DAILY_QUOTA).to_i
+      return :quota_denied if Canvas.redis.get(quota_key(account)).to_i >= limit
+
+      :allowed
+    end
+
     def self.acquire_cooldown(user:, discussion_topic:)
       seconds = Setting.get(COOLDOWN_SETTING_KEY, DEFAULT_COOLDOWN_SECONDS).to_i
       Canvas.redis.set(cooldown_key(user, discussion_topic), 1, nx: true, ex: seconds)

--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -29,6 +29,17 @@ module DiscussionThreadSummarizer
 
     CacheResult = Struct.new(:status, :record, :result, keyword_init: true)
 
+    RenderState = %i[
+      current
+      stale
+      generating
+      rate_limited_stale
+      rate_limited_empty
+      disabled
+    ].freeze
+
+    RenderResult = Struct.new(:status, :record, :result, :enqueued, keyword_init: true)
+
     # Enqueues a background summary attempt via Delayed Job.
     # Mirrors the insight_generation pattern in DiscussionTopicsApiController.
     # Singleton + n_strand ensure at most one job per topic runs at a time.
@@ -91,6 +102,51 @@ module DiscussionThreadSummarizer
       CacheResult.new(status: :miss, record: record, result: result)
     end
 
+    # Render-time lookup: read-only with respect to the model and rate-limit budget.
+    def lookup_for_render(discussion_topic:, viewer:, locale: I18n.locale.to_s)
+      course = discussion_topic.context
+      unless course.is_a?(Course) && course.feature_enabled?(:discussion_thread_summarizer)
+        if course.is_a?(Course)
+          DiscussionThreadSummarizer::Metrics.increment_render_disabled(account: course.root_account)
+        end
+        return RenderResult.new(status: :disabled, record: nil, result: nil, enqueued: false)
+      end
+
+      account = discussion_topic.context.root_account
+      record      = find_latest_summary_row(discussion_topic, locale)
+      current_hash = ContentVersionHash.call(discussion_topic)
+
+      # NOTE: This is the render-time lookup. Distinct from #fetch_or_create_summary
+      # (cache miss path that actually invokes the model). Read-only with respect to
+      # the model and rate-limit budget — uses RegenerationRateLimiter.preview, never
+      # .check. Enqueue happens here when state is :stale or :generating AND preview
+      # allows. The job's miss path will consult .check authoritatively; race between
+      # preview-allow and job-deny is acceptable (one-cycle delay).
+      #
+      # Hash race: ContentVersionHash.call(topic) is computed after the row fetch.
+      # Concurrent entry edits can make :current appear :stale (or vice versa) for
+      # one request. Self-corrects on next render. Matches the legacy summary
+      # `obsolete` flag race semantics (discussion_topics_api_controller.rb:135).
+      #
+      # Singleton: enqueue_for keys only discussion_topic.id (not locale). Multiple
+      # locales requesting refresh for the same topic share one Delayed::Job; the job
+      # runs fetch_or_create_summary with the viewer/locale from whichever enqueue won.
+
+      if record.nil?
+        build_generating_or_rate_limited_empty(discussion_topic:, viewer:, locale:, account:)
+      elsif record.dynamic_content_hash == current_hash
+        DiscussionThreadSummarizer::Metrics.increment_render_current(account:)
+        RenderResult.new(
+          status: :current,
+          record:,
+          result: parse_summary_record(record),
+          enqueued: false
+        )
+      else
+        build_stale_or_rate_limited_stale(discussion_topic:, viewer:, locale:, account:, record:)
+      end
+    end
+
     def summarize(discussion_topic:, viewer:)
       account = discussion_topic.context.root_account
       payload = gather(discussion_topic, viewer)
@@ -121,6 +177,42 @@ module DiscussionThreadSummarizer
     end
 
     private
+
+    def find_latest_summary_row(discussion_topic, locale)
+      discussion_topic.summaries
+                      .where(
+                        llm_config_version: LLM_CONFIG_VERSION,
+                        parent_id: nil,
+                        locale:
+                      )
+                      .order(created_at: :desc)
+                      .first
+    end
+
+    def build_generating_or_rate_limited_empty(discussion_topic:, viewer:, locale:, account:)
+      case RegenerationRateLimiter.preview(account:, user: viewer, discussion_topic:)
+      when :cooldown_denied, :quota_denied
+        DiscussionThreadSummarizer::Metrics.increment_render_rate_limited_empty(account:)
+        RenderResult.new(status: :rate_limited_empty, record: nil, result: nil, enqueued: false)
+      else
+        self.class.enqueue_for(discussion_topic:, viewer:)
+        DiscussionThreadSummarizer::Metrics.increment_render_generating(account:)
+        RenderResult.new(status: :generating, record: nil, result: nil, enqueued: true)
+      end
+    end
+
+    def build_stale_or_rate_limited_stale(discussion_topic:, viewer:, locale:, account:, record:)
+      parsed = parse_summary_record(record)
+      case RegenerationRateLimiter.preview(account:, user: viewer, discussion_topic:)
+      when :cooldown_denied, :quota_denied
+        DiscussionThreadSummarizer::Metrics.increment_render_rate_limited_stale(account:)
+        RenderResult.new(status: :rate_limited_stale, record:, result: parsed, enqueued: false)
+      else
+        self.class.enqueue_for(discussion_topic:, viewer:)
+        DiscussionThreadSummarizer::Metrics.increment_render_stale(account:)
+        RenderResult.new(status: :stale, record:, result: parsed, enqueued: true)
+      end
+    end
 
     def find_cached_summary(discussion_topic, content_hash, locale)
       # NOTE: Cache key assumes discussion_thread_summarizer_scope_limited is OFF.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1639,6 +1639,7 @@ CanvasRails::Application.routes.draw do
         delete "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id", controller: :discussion_topics, action: :destroy
 
         get "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/view", action: :view, as: "#{context}_discussion_topic_view"
+        get "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/thread_summary", action: :thread_summary, as: "#{context}_discussion_topic_thread_summary"
         get "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/summaries", action: :find_summary, as: "#{context}_discussion_topic_summary"
         post "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/summaries", action: :find_or_create_summary, as: "#{context}_discussion_topic_create_summary"
         put "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/summaries/disable", action: :disable_summary, as: "#{context}_discussion_topic_disable_summary"

--- a/lib/discussion_thread_summarizer/metrics.rb
+++ b/lib/discussion_thread_summarizer/metrics.rb
@@ -112,6 +112,54 @@ module DiscussionThreadSummarizer
       )
     end
 
+    # Emitted when render lookup serves a current (hash-matched) summary.
+    def self.increment_render_current(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.render.current",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Emitted when render lookup serves a stale summary (hash orphan).
+    def self.increment_render_stale(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.render.stale",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Emitted when render lookup finds no summary row for the locale.
+    def self.increment_render_generating(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.render.generating",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Emitted when preview denies refresh and a stale row exists.
+    def self.increment_render_rate_limited_stale(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.render.rate_limited_stale",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Emitted when preview denies refresh and no summary row exists.
+    def self.increment_render_rate_limited_empty(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.render.rate_limited_empty",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Emitted when the feature flag is off at render lookup time.
+    def self.increment_render_disabled(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.render.disabled",
+        tags: { account_id: account.global_id }
+      )
+    end
+
     # Emitted when a user submits an inaccuracy report against a summary.
     # reason_category: one of "inaccurate", "missed_viewpoint",
     #                  "harmful_content", "other"

--- a/spec/controllers/discussion_topics_api_controller_spec.rb
+++ b/spec/controllers/discussion_topics_api_controller_spec.rb
@@ -1358,4 +1358,68 @@ describe DiscussionTopicsApiController do
       end
     end
   end
+
+  context "thread_summary (Discussion Thread Summarizer)" do
+    before do
+      course_with_student(active_all: true)
+      @course.enable_feature!(:discussion_thread_summarizer)
+      @topic = @course.discussion_topics.create!(title: "discussion")
+      @topic.discussion_entries.create!(user: @student, message: "hello")
+      user_session(@student)
+      allow(Canvas).to receive(:redis_enabled?).and_return(true)
+      allow(Canvas.redis).to receive(:get).and_return(nil)
+    end
+
+    it "returns HTTP 200 with disabled payload when the feature flag is off" do
+      @course.disable_feature!(:discussion_thread_summarizer)
+
+      get "thread_summary",
+          params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+          format: "json"
+
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq(
+        "status" => "disabled",
+        "enabled" => false,
+        "enqueued" => false
+      )
+    end
+
+    it "returns current status with summary JSON when the cache row matches" do
+      content_hash = DiscussionThreadSummarizer::ContentVersionHash.call(@topic)
+      @topic.summaries.create!(
+        user: @student,
+        locale: "en",
+        summary: DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE.to_json,
+        dynamic_content_hash: content_hash,
+        llm_config_version: DiscussionThreadSummarizer::SummarizationService::LLM_CONFIG_VERSION
+      )
+
+      get "thread_summary",
+          params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+          format: "json"
+
+      expect(response).to be_successful
+      body = response.parsed_body
+      expect(body["status"]).to eq("current")
+      expect(body["enabled"]).to be(true)
+      expect(body["enqueued"]).to be(false)
+      expect(body["summary"]).to eq(
+        DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE.deep_stringify_keys
+      )
+    end
+
+    it "returns generating status and enqueues when no summary row exists" do
+      expect do
+        get "thread_summary",
+            params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+            format: "json"
+      end.to change { Delayed::Job.count }.by(1)
+
+      body = response.parsed_body
+      expect(body["status"]).to eq("generating")
+      expect(body["enqueued"]).to be(true)
+      expect(body["summary"]).to be_nil
+    end
+  end
 end

--- a/spec/services/discussion_thread_summarizer/integration/render_lookup_spec.rb
+++ b/spec/services/discussion_thread_summarizer/integration/render_lookup_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+describe "DiscussionThreadSummarizer render lookup integration" do
+  let(:course)  { course_factory(active_all: true) }
+  let(:teacher) { teacher_in_course(course:, active_all: true).user }
+  let(:topic) do
+    course.discussion_topics.create!(
+      title:   "Test thread",
+      message: "Discuss here",
+      user:    teacher
+    )
+  end
+  let(:service) { DiscussionThreadSummarizer::SummarizationService.new }
+
+  before do
+    course.enable_feature!(:discussion_thread_summarizer)
+    topic.discussion_entries.create!(user: teacher, message: "Teacher says hello.")
+    allow(Canvas).to receive(:redis_enabled?).and_return(true)
+    allow(Canvas.redis).to receive(:get).and_return(nil)
+    allow(Rails.logger).to receive(:info)
+  end
+
+  it "generating lookup enqueues a job and a subsequent lookup is :current after run_jobs" do
+    first = service.lookup_for_render(discussion_topic: topic, viewer: teacher, locale: "en")
+
+    expect(first.status).to eq(:generating)
+    expect(first.enqueued).to be(true)
+
+    expect { run_jobs }.not_to raise_error
+
+    second = service.lookup_for_render(discussion_topic: topic, viewer: teacher, locale: "en")
+
+    expect(second.status).to eq(:current)
+    expect(second.result).to eq(DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE)
+    expect(topic.summaries.count).to eq(1)
+  end
+end

--- a/spec/services/discussion_thread_summarizer/regeneration_rate_limiter_spec.rb
+++ b/spec/services/discussion_thread_summarizer/regeneration_rate_limiter_spec.rb
@@ -174,4 +174,30 @@ describe DiscussionThreadSummarizer::RegenerationRateLimiter do
       "You may remove the 'rate_limit' option from the LLMConfig to disable rate limiting."
     )
   end
+
+  describe ".preview" do
+    it "does not mutate Redis (no SET, INCR, DECR, or EXPIRE)" do
+      allow(Canvas.redis).to receive(:get).and_return(nil)
+      expect(Canvas.redis).not_to receive(:set)
+      expect(Canvas.redis).not_to receive(:incr)
+      expect(Canvas.redis).not_to receive(:decr)
+      expect(Canvas.redis).not_to receive(:expire)
+
+      described_class.preview(account:, user:, discussion_topic: topic)
+    end
+
+    it "checks cooldown before quota and does not read quota when cooldown key is present" do
+      allow(Canvas.redis).to receive(:get).with(cooldown_key).and_return("1")
+      expect(Canvas.redis).not_to receive(:get).with(quota_key)
+
+      expect(described_class.preview(account:, user:, discussion_topic: topic)).to eq(:cooldown_denied)
+    end
+
+    it "returns :quota_denied when the daily counter is at the limit" do
+      allow(Canvas.redis).to receive(:get).with(cooldown_key).and_return(nil)
+      allow(Canvas.redis).to receive(:get).with(quota_key).and_return("100")
+
+      expect(described_class.preview(account:, user:, discussion_topic: topic)).to eq(:quota_denied)
+    end
+  end
 end

--- a/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
+++ b/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
@@ -633,3 +633,145 @@ describe "DiscussionThreadSummarizer::SummarizationService#fetch_or_create_summa
     end
   end
 end
+
+# Render-path lookup (Cycle 19, #84) — separate describe; described_class must be SummarizationService.
+describe DiscussionThreadSummarizer::SummarizationService, "#lookup_for_render" do
+  let(:lookup_course)  { course_model }
+  let(:lookup_user)    { user_model }
+  let(:lookup_topic)   { lookup_course.discussion_topics.create! }
+  let(:stub_client)    { DiscussionThreadSummarizer::StubModelClient.new }
+  let(:lookup_service) { described_class.new(client: stub_client) }
+  let(:lookup_locale)  { "en" }
+  let(:lookup_hash)    { DiscussionThreadSummarizer::ContentVersionHash.call(lookup_topic) }
+
+  before do
+    lookup_course.enable_feature!(:discussion_thread_summarizer)
+    lookup_topic.discussion_entries.create!(user: lookup_user, message: "hello")
+    allow(Canvas).to receive(:redis_enabled?).and_return(true)
+    allow(Canvas.redis).to receive(:get).and_return(nil)
+  end
+
+  def seed_lookup_summary(hash: lookup_hash, locale: lookup_locale, created_at: Time.zone.now)
+    lookup_topic.summaries.create!(
+      user: lookup_user,
+      locale:,
+      summary: DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE.to_json,
+      dynamic_content_hash: hash,
+      llm_config_version: described_class::LLM_CONFIG_VERSION,
+      created_at:
+    )
+  end
+
+  it "returns :disabled without touching Redis when the feature flag is off" do
+    lookup_course.disable_feature!(:discussion_thread_summarizer)
+    expect(Canvas.redis).not_to receive(:get)
+
+    result = lookup_service.lookup_for_render(
+      discussion_topic: lookup_topic,
+      viewer: lookup_user,
+      locale: lookup_locale
+    )
+
+    expect(result.status).to eq(:disabled)
+    expect(result.enqueued).to be(false)
+  end
+
+  it "returns :current without enqueuing when the latest row hash matches" do
+    seed_lookup_summary
+    expect(described_class).not_to receive(:enqueue_for)
+
+    result = lookup_service.lookup_for_render(
+      discussion_topic: lookup_topic,
+      viewer: lookup_user,
+      locale: lookup_locale
+    )
+
+    expect(result.status).to eq(:current)
+    expect(result.enqueued).to be(false)
+    expect(result.result).to eq(DiscussionThreadSummarizer::StubModelClient::FIXED_RESPONSE)
+  end
+
+  it "returns :stale and enqueues when the row hash is an orphan" do
+    seed_lookup_summary(hash: "0" * 64)
+    expect(described_class).to receive(:enqueue_for).with(
+      discussion_topic: lookup_topic,
+      viewer: lookup_user
+    )
+
+    result = lookup_service.lookup_for_render(
+      discussion_topic: lookup_topic,
+      viewer: lookup_user,
+      locale: lookup_locale
+    )
+
+    expect(result.status).to eq(:stale)
+    expect(result.enqueued).to be(true)
+  end
+
+  it "returns :generating and enqueues when no summary row exists" do
+    expect(described_class).to receive(:enqueue_for).with(
+      discussion_topic: lookup_topic,
+      viewer: lookup_user
+    )
+
+    result = lookup_service.lookup_for_render(
+      discussion_topic: lookup_topic,
+      viewer: lookup_user,
+      locale: lookup_locale
+    )
+
+    expect(result.status).to eq(:generating)
+    expect(result.record).to be_nil
+    expect(result.enqueued).to be(true)
+  end
+
+  it "returns :rate_limited_stale without enqueuing when preview denies and a row exists" do
+    seed_lookup_summary(hash: "0" * 64)
+    cooldown = ["discussion_thread_summarizer", "cooldown", lookup_user.id, lookup_topic.id].cache_key
+    allow(Canvas.redis).to receive(:get) { |key| key == cooldown ? "1" : nil }
+    expect(described_class).not_to receive(:enqueue_for)
+
+    result = lookup_service.lookup_for_render(
+      discussion_topic: lookup_topic,
+      viewer: lookup_user,
+      locale: lookup_locale
+    )
+
+    expect(result.status).to eq(:rate_limited_stale)
+    expect(result.enqueued).to be(false)
+  end
+
+  it "returns :rate_limited_empty without enqueuing when preview denies and no row exists" do
+    cooldown = ["discussion_thread_summarizer", "cooldown", lookup_user.id, lookup_topic.id].cache_key
+    allow(Canvas.redis).to receive(:get) { |key| key == cooldown ? "1" : nil }
+    expect(described_class).not_to receive(:enqueue_for)
+
+    result = lookup_service.lookup_for_render(
+      discussion_topic: lookup_topic,
+      viewer: lookup_user,
+      locale: lookup_locale
+    )
+
+    expect(result.status).to eq(:rate_limited_empty)
+    expect(result.enqueued).to be(false)
+  end
+
+  it "uses the latest orphan row when multiple rows exist for the same locale" do
+    seed_lookup_summary(hash: "0" * 64, created_at: 2.hours.ago)
+    newer = seed_lookup_summary(
+      hash: "1" * 64,
+      created_at: 1.hour.ago,
+      locale: lookup_locale
+    )
+    allow(described_class).to receive(:enqueue_for)
+
+    result = lookup_service.lookup_for_render(
+      discussion_topic: lookup_topic,
+      viewer: lookup_user,
+      locale: lookup_locale
+    )
+
+    expect(result.record.id).to eq(newer.id)
+    expect(result.status).to eq(:stale)
+  end
+end


### PR DESCRIPTION
## Summary

Cycle 19 API/lookup slice for #84 (React/UI tracked separately in #95).

- `SummarizationService#lookup_for_render` → `RenderResult` with `RenderState` (`:current`, `:stale`, `:generating`, `:rate_limited_stale`, `:rate_limited_empty`, `:disabled`)
- `RegenerationRateLimiter.preview` — read-only probe (cooldown-before-quota; no Redis mutations)
- Six render-state metrics on `DiscussionThreadSummarizer::Metrics`
- `GET /api/v1/courses/:course_id/discussion_topics/:topic_id/thread_summary` — `:disabled` returns HTTP 200 with `{ status: "disabled", enabled: false }`

## Tripwires

- No `ContentVersionHash` / `CacheInvalidation` edits
- No change to `RegenerationRateLimiter.check` or `#fetch_or_create_summary` / `CacheResult`
- No new feature flags, migration, React/JS, admin bypass, or audit DB

## Diff overage (raised cap 350)

Combined **481** lines (impl ~194 + spec ~287). Surfaces over the 350 raised cap for render-path slices per cycle convention. Trim options from Checkpoint 1 not applied — integration spec is load-bearing for enqueue → job → cache lifecycle.

## Singleton key / locale

`enqueue_for` singleton is `discussion_thread_summarizer:generation_for_topic:#{discussion_topic.id}` — **no locale**. Multi-locale render requests for the same topic collapse to one delayed job (mirrors Cycle 12 / `insight_generation` pattern). Document for #21 and #95 contract.

## Test plan

- [x] `bin/rspec spec/services/discussion_thread_summarizer/regeneration_rate_limiter_spec.rb`
- [x] `bin/rspec spec/services/discussion_thread_summarizer/summarization_service_spec.rb` (lookup_for_render context)
- [x] `bin/rspec spec/controllers/discussion_topics_api_controller_spec.rb` (thread_summary)
- [x] `bin/rspec spec/services/discussion_thread_summarizer/integration/render_lookup_spec.rb`
- Seed 1: 141 examples in touched files, 0 failures

Closes #84