### PR TITLE
[M3] Cache observability metrics (closes #20)

### DIFF
--- a/app/services/discussion_thread_summarizer/cache_invalidation.rb
+++ b/app/services/discussion_thread_summarizer/cache_invalidation.rb
@@ -47,12 +47,14 @@ module DiscussionThreadSummarizer
       return unless enabled?
 
       Metrics.increment_invalidation_fired(cause: "create", account:)
+      Metrics.increment_cache_invalidated(trigger: "reply_create", account:)
     end
 
     def handle_deleted
       return unless enabled?
 
       Metrics.increment_invalidation_fired(cause: "delete", account:)
+      Metrics.increment_cache_invalidated(trigger: "reply_delete", account:)
     end
 
     def handle_updated(message_before:, message_after:)
@@ -64,6 +66,7 @@ module DiscussionThreadSummarizer
         Metrics.increment_invalidation_skipped_below_threshold(account:)
       else
         Metrics.increment_invalidation_fired(cause: "edit", account:)
+        Metrics.increment_cache_invalidated(trigger: "reply_edit", account:)
       end
     end
 

--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -58,6 +58,17 @@ module DiscussionThreadSummarizer
     # Cache-aware entrypoint: O(1) lookup by content hash + config version + locale.
     # On hit, returns stored summary without calling the model client.
     def fetch_or_create_summary(discussion_topic:, viewer:, locale: I18n.locale.to_s)
+      course = discussion_topic.context
+      unless course.is_a?(Course) && course.feature_enabled?(:discussion_thread_summarizer)
+        # Defense-in-depth flag gate mirroring #lookup_for_render guard. Production
+        # callers (job, controller) already gate the flag before reaching here; this
+        # guard prevents accidental invocation from misconfigured contexts. See #20 DoD.
+        # Returns :rate_limited without invoking the limiter or model — not a real deny,
+        # but the closest frozen CacheResult.status that blocks regeneration (no :disabled
+        # in the pipeline enum). Documented in Cycle 20 evidence.
+        return CacheResult.new(status: :rate_limited, record: nil, result: nil)
+      end
+
       account      = discussion_topic.context.root_account
       content_hash = ContentVersionHash.call(discussion_topic)
       cached       = find_cached_summary(discussion_topic, content_hash, locale)
@@ -206,10 +217,12 @@ module DiscussionThreadSummarizer
       case RegenerationRateLimiter.preview(account:, user: viewer, discussion_topic:)
       when :cooldown_denied, :quota_denied
         DiscussionThreadSummarizer::Metrics.increment_render_rate_limited_stale(account:)
+        DiscussionThreadSummarizer::Metrics.increment_cache_stale(account:)
         RenderResult.new(status: :rate_limited_stale, record:, result: parsed, enqueued: false)
       else
         self.class.enqueue_for(discussion_topic:, viewer:)
         DiscussionThreadSummarizer::Metrics.increment_render_stale(account:)
+        DiscussionThreadSummarizer::Metrics.increment_cache_stale(account:)
         RenderResult.new(status: :stale, record:, result: parsed, enqueued: true)
       end
     end

--- a/doc/discussion_thread_summarizer_observability.md
+++ b/doc/discussion_thread_summarizer_observability.md
@@ -1,0 +1,3 @@
+# Discussion Thread Summarizer — observability (M3)
+
+Cycle 20 completes the NFR-4 `cache.*` metric family alongside existing `render.*` (render-state) and `invalidation.*` (write-side) families. These are **parallel telemetry paths**, not aliases: stale summary serve dual-emits `render.stale` and `cache.stale`; invalidation dual-emits `invalidation.fired` and `cache.invalidated` (with `trigger:` `reply_create` / `reply_edit` / `reply_delete`). Stale-to-fresh ratio dashboards are tracked in issue #50.

--- a/lib/discussion_thread_summarizer/metrics.rb
+++ b/lib/discussion_thread_summarizer/metrics.rb
@@ -61,6 +61,28 @@ module DiscussionThreadSummarizer
       )
     end
 
+    # Part of the cache.* family (NFR-4: cache effectiveness telemetry). Parallel to
+    # render.stale and render.rate_limited_stale, which serve render-state dashboards.
+    # Both render states fire cache.stale because both serve orphan-hash content from
+    # the cache without regeneration. Dual-emit is intentional — see Cycle 20 evidence.
+    def self.increment_cache_stale(account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.cache.stale",
+        tags: { account_id: account.global_id }
+      )
+    end
+
+    # Part of the cache.* family (NFR-4). Parallel to invalidation.fired (Cycle 17),
+    # which serves write-side event dashboards. Same callsites; trigger tag uses
+    # reply_* values per #20 AC (reply_create / reply_edit / reply_delete), while
+    # invalidation.fired uses cause: create/edit/delete. Dual-emit is intentional.
+    def self.increment_cache_invalidated(trigger:, account:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.cache.invalidated",
+        tags: { account_id: account.global_id, trigger: }
+      )
+    end
+
     # Emitted when generation fails for any reason.
     # reason: one of "quota_exceeded", "throttled", "schema_invalid",
     #         "transport_error", "unknown"

--- a/spec/lib/discussion_thread_summarizer/metrics_spec.rb
+++ b/spec/lib/discussion_thread_summarizer/metrics_spec.rb
@@ -66,6 +66,26 @@ describe DiscussionThreadSummarizer::Metrics do
     end
   end
 
+  describe ".increment_cache_stale" do
+    it "emits discussion_thread_summarizer.cache.stale with account_id tag" do
+      described_class.increment_cache_stale(account:)
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.cache.stale",
+        tags: { account_id: 10_000_000_000_001 }
+      )
+    end
+  end
+
+  describe ".increment_cache_invalidated" do
+    it "emits discussion_thread_summarizer.cache.invalidated with account_id and trigger tags" do
+      described_class.increment_cache_invalidated(trigger: "reply_edit", account:)
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.cache.invalidated",
+        tags: { account_id: 10_000_000_000_001, trigger: "reply_edit" }
+      )
+    end
+  end
+
   describe ".increment_failure" do
     it "emits discussion_thread_summarizer.failure with account_id and reason tags" do
       described_class.increment_failure(reason: "timeout", account:)

--- a/spec/services/discussion_thread_summarizer/cache_invalidation_spec.rb
+++ b/spec/services/discussion_thread_summarizer/cache_invalidation_spec.rb
@@ -57,9 +57,17 @@ describe DiscussionThreadSummarizer::CacheInvalidation do
     ]
   end
 
+  def invalidated_metric(trigger:)
+    [
+      "discussion_thread_summarizer.cache.invalidated",
+      { tags: { account_id: account.global_id, trigger: } }
+    ]
+  end
+
   it "fires invalidation.fired cause create on handle_entry_created" do
     described_class.handle_entry_created(entry)
     expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(*fired_metric(cause: "create"))
+    expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(*invalidated_metric(trigger: "reply_create"))
     expect(InstStatsd::Statsd).not_to have_received(:distributed_increment).with(*skipped_metric)
   end
 
@@ -88,6 +96,7 @@ describe DiscussionThreadSummarizer::CacheInvalidation do
   it "fires invalidation.fired cause delete on handle_entry_deleted" do
     described_class.handle_entry_deleted(entry)
     expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(*fired_metric(cause: "delete"))
+    expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(*invalidated_metric(trigger: "reply_delete"))
   end
 
   it "does not route editor_id-only saves through invalidation handlers" do

--- a/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
+++ b/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
@@ -475,8 +475,24 @@ describe "DiscussionThreadSummarizer::SummarizationService#fetch_or_create_summa
   let(:content_hash)   { DiscussionThreadSummarizer::ContentVersionHash.call(topic) }
 
   before do
+    course.enable_feature!(:discussion_thread_summarizer)
     topic.discussion_entries.create!(user:, message: "hello")
     allow(Rails.logger).to receive(:info)
+  end
+
+  it "returns :rate_limited without cache or model work when the feature flag is off" do
+    course.disable_feature!(:discussion_thread_summarizer)
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_cache_hit)
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_cache_miss)
+    allow(stub_client).to receive(:summarize).and_call_original
+
+    result = service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+    expect(result.status).to eq(:rate_limited)
+    expect(result.record).to be_nil
+    expect(stub_client).not_to have_received(:summarize)
+    expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_cache_hit)
+    expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_cache_miss)
   end
 
   def seed_summary(locale: "en", hash: content_hash, summary_json: nil)
@@ -693,6 +709,8 @@ describe DiscussionThreadSummarizer::SummarizationService, "#lookup_for_render" 
 
   it "returns :stale and enqueues when the row hash is an orphan" do
     seed_lookup_summary(hash: "0" * 64)
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_render_stale)
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_cache_stale)
     expect(described_class).to receive(:enqueue_for).with(
       discussion_topic: lookup_topic,
       viewer: lookup_user
@@ -706,6 +724,8 @@ describe DiscussionThreadSummarizer::SummarizationService, "#lookup_for_render" 
 
     expect(result.status).to eq(:stale)
     expect(result.enqueued).to be(true)
+    expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_cache_stale)
+      .with(account: lookup_course.root_account)
   end
 
   it "returns :generating and enqueues when no summary row exists" do
@@ -729,6 +749,8 @@ describe DiscussionThreadSummarizer::SummarizationService, "#lookup_for_render" 
     seed_lookup_summary(hash: "0" * 64)
     cooldown = ["discussion_thread_summarizer", "cooldown", lookup_user.id, lookup_topic.id].cache_key
     allow(Canvas.redis).to receive(:get) { |key| key == cooldown ? "1" : nil }
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_render_rate_limited_stale)
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_cache_stale)
     expect(described_class).not_to receive(:enqueue_for)
 
     result = lookup_service.lookup_for_render(
@@ -739,6 +761,8 @@ describe DiscussionThreadSummarizer::SummarizationService, "#lookup_for_render" 
 
     expect(result.status).to eq(:rate_limited_stale)
     expect(result.enqueued).to be(false)
+    expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_cache_stale)
+      .with(account: lookup_course.root_account)
   end
 
   it "returns :rate_limited_empty without enqueuing when preview denies and no row exists" do


### PR DESCRIPTION
## Summary

Cycle 20 M3 observability close-out (#20).

- `Metrics.increment_cache_stale` → `cache.stale` (dual-emit with `render.stale` / `render.rate_limited_stale`)
- `Metrics.increment_cache_invalidated(trigger:)` → `cache.invalidated` (dual-emit with `invalidation.fired`)
- Flag gate on `#fetch_or_create_summary` (defense-in-depth)
- Release note: `doc/discussion_thread_summarizer_observability.md`

## Flag-gate return shape

Does **not** extend `CacheResult.status`. When flag is off, returns `CacheResult.new(status: :rate_limited, record: nil, result: nil)` **without** calling the limiter or model and **without** cache/rate-limit metrics. `:rate_limited` is a frozen pipeline enum value used only to block regeneration; documented in evidence.

## Diff vs cap

**94 lines** (impl ~38 + spec ~53 + doc 3) — **under** 200 soft / 250 hard (first cycle under cap after 17–19 overages).

## Tripwires

No renames of shipped metrics; no `ContentVersionHash` / limiter / render API changes; no new flags; PR closes **#20 only**.

## Test plan

- [x] 66 examples, 0 failures, seed 1 (~21s) on metrics, cache_invalidation, summarization_service specs

Closes #20