### PR TITLE
[M4] Thread summary UI block + polling hook (closes #95)

### DIFF
--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/ThreadSummaryBlock.tsx
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/ThreadSummaryBlock.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import {useScope as createI18nScope} from '@canvas/i18n'
+import {Alert} from '@instructure/ui-alerts'
+import {Flex} from '@instructure/ui-flex'
+import {Heading} from '@instructure/ui-heading'
+import {Spinner} from '@instructure/ui-spinner'
+import {Text} from '@instructure/ui-text'
+import {View} from '@instructure/ui-view'
+import {formatThreadSummary} from './formatThreadSummary'
+import {useThreadSummary} from './useThreadSummary'
+
+const I18n = createI18nScope('discussion_topics_post')
+
+export const ThreadSummaryBlock = () => {
+  const {data, loading, error} = useThreadSummary()
+
+  if ((loading && !data) || !data || data.status === 'disabled') {
+    return null
+  }
+
+  if (error) {
+    return (
+      <View as="div" margin="0 0 medium 0" data-testid="thread-summary-block">
+        <Text color="danger" data-testid="thread-summary-error">
+          {I18n.t('Unable to load thread summary.')}
+        </Text>
+      </View>
+    )
+  }
+
+  const summaryText = formatThreadSummary(data.summary)
+
+  const renderSummaryText = () => {
+    if (!summaryText) {
+      return null
+    }
+    return (
+      <Flex.Item margin="0 0 small 0">
+        <Text data-testid="thread-summary-text">{summaryText}</Text>
+      </Flex.Item>
+    )
+  }
+
+  const renderContent = () => {
+    switch (data.status) {
+      case 'generating':
+        return (
+          <div role="status" aria-live="polite" data-testid="thread-summary-generating">
+            <Flex alignItems="center">
+              <Flex.Item>
+                <Spinner renderTitle={I18n.t('Generating thread summary')} size="x-small" />
+              </Flex.Item>
+              <Flex.Item margin="0 0 0 x-small">
+                <Text>{I18n.t('Generating thread summary...')}</Text>
+              </Flex.Item>
+            </Flex>
+          </div>
+        )
+      case 'rate_limited_empty':
+        return (
+          <Text data-testid="thread-summary-rate-limited-empty">
+            {I18n.t('Summary unavailable; try again later.')}
+          </Text>
+        )
+      case 'stale':
+        return (
+          <>
+            <Flex.Item margin="0 0 small 0">
+              <Alert
+                variant="info"
+                margin="0"
+                hasShadow={false}
+                data-testid="thread-summary-stale-alert"
+              >
+                {I18n.t(
+                  'This summary may be outdated because the discussion has new activity.',
+                )}
+              </Alert>
+            </Flex.Item>
+            {renderSummaryText()}
+          </>
+        )
+      case 'rate_limited_stale':
+        return (
+          <>
+            {renderSummaryText()}
+            <Flex.Item margin="small 0 0 0">
+              <Text data-testid="thread-summary-rate-limited-stale">
+                {I18n.t('Summary may be outdated; refresh limit reached.')}
+              </Text>
+            </Flex.Item>
+          </>
+        )
+      case 'current':
+        return renderSummaryText()
+      default:
+        return null
+    }
+  }
+
+  return (
+    <View
+      as="div"
+      margin="0 0 medium 0"
+      padding="small"
+      data-testid="thread-summary-block"
+    >
+      <Flex direction="column">
+        <Flex.Item margin="0 0 small 0">
+          <Heading level="h3">{I18n.t('Thread summary')}</Heading>
+          <Text size="small" color="secondary">
+            {I18n.t('AI-generated thread summary')}
+          </Text>
+        </Flex.Item>
+        {renderContent()}
+      </Flex>
+    </View>
+  )
+}

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/ThreadSummaryBlock.test.tsx
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/ThreadSummaryBlock.test.tsx
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import {act, render, waitFor} from '@testing-library/react'
+import fakeENV from '@canvas/test-utils/fakeENV'
+import {setupServer} from 'msw/node'
+import {http, HttpResponse} from 'msw'
+import {ThreadSummaryBlock} from '../ThreadSummaryBlock'
+import type {ThreadSummaryData} from '../useThreadSummary'
+
+const server = setupServer()
+
+declare const ENV: {
+  discussion_topic_id: string
+  context_id: string
+  context_type: string
+  LOCALE: string
+  discussion_thread_summarizer_enabled?: boolean
+}
+
+const sampleSummary = {
+  themes: ['Main theme A'],
+  viewpoints: ['Majority viewpoint'],
+  open_questions: ['What are the next steps?'],
+  scope_mode: 'default',
+}
+
+const threadSummaryPath =
+  '/api/v1/courses/1234/discussion_topics/5678/thread_summary'
+
+const setup = () => render(<ThreadSummaryBlock />)
+
+describe('ThreadSummaryBlock', () => {
+  beforeAll(() => server.listen())
+
+  afterAll(() => server.close())
+
+  beforeEach(() => {
+    fakeENV.setup({
+      discussion_topic_id: '5678',
+      context_id: '1234',
+      context_type: 'Course',
+      LOCALE: 'en',
+      discussion_thread_summarizer_enabled: true,
+    })
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    fakeENV.teardown()
+    server.resetHandlers()
+    vi.useRealTimers()
+  })
+
+  const mockThreadSummary = (body: ThreadSummaryData) => {
+    server.use(http.get(threadSummaryPath, () => HttpResponse.json(body)))
+  }
+
+  it('does not render when the API returns disabled', async () => {
+    mockThreadSummary({
+      status: 'disabled',
+      enabled: false,
+      enqueued: false,
+      summary: null,
+      record_id: null,
+    })
+
+    const {queryByTestId} = setup()
+
+    await waitFor(() => {
+      expect(queryByTestId('thread-summary-block')).toBeNull()
+    })
+  })
+
+  it('renders summary text when status is current', async () => {
+    mockThreadSummary({
+      status: 'current',
+      enabled: true,
+      enqueued: false,
+      summary: sampleSummary,
+      record_id: 1,
+    })
+
+    const {findByTestId} = setup()
+
+    const text = await findByTestId('thread-summary-text')
+    expect(text.textContent).toContain('Main theme A')
+  })
+
+  it('renders stale alert and summary text when status is stale', async () => {
+    mockThreadSummary({
+      status: 'stale',
+      enabled: true,
+      enqueued: true,
+      summary: sampleSummary,
+      record_id: 1,
+    })
+
+    const {findByTestId} = setup()
+
+    expect(await findByTestId('thread-summary-stale-alert')).toBeInTheDocument()
+    expect(await findByTestId('thread-summary-text')).toBeInTheDocument()
+  })
+
+  it('renders generating state with aria-live region', async () => {
+    mockThreadSummary({
+      status: 'generating',
+      enabled: true,
+      enqueued: true,
+      summary: null,
+      record_id: null,
+    })
+
+    const {findByTestId} = setup()
+
+    const generating = await findByTestId('thread-summary-generating')
+    expect(generating).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('polls again after 5 seconds while status is generating', async () => {
+    vi.useFakeTimers({toFake: ['setInterval', 'clearInterval']})
+    let requestCount = 0
+
+    server.use(
+      http.get(threadSummaryPath, () => {
+        requestCount += 1
+        if (requestCount === 1) {
+          return HttpResponse.json({
+            status: 'generating',
+            enabled: true,
+            enqueued: true,
+            summary: null,
+            record_id: null,
+          })
+        }
+        return HttpResponse.json({
+          status: 'current',
+          enabled: true,
+          enqueued: false,
+          summary: sampleSummary,
+          record_id: 1,
+        })
+      }),
+    )
+
+    const {findByTestId} = setup()
+
+    await findByTestId('thread-summary-generating')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    await waitFor(() => {
+      expect(requestCount).toBeGreaterThanOrEqual(2)
+    })
+    expect(await findByTestId('thread-summary-text')).toBeInTheDocument()
+  })
+
+  it('renders rate_limited_empty message without summary text', async () => {
+    mockThreadSummary({
+      status: 'rate_limited_empty',
+      enabled: true,
+      enqueued: false,
+      summary: null,
+      record_id: null,
+    })
+
+    const {findByTestId, queryByTestId} = setup()
+
+    expect(await findByTestId('thread-summary-rate-limited-empty')).toBeInTheDocument()
+    expect(queryByTestId('thread-summary-text')).toBeNull()
+  })
+
+  it('renders rate_limited_stale with summary and limit message', async () => {
+    mockThreadSummary({
+      status: 'rate_limited_stale',
+      enabled: true,
+      enqueued: false,
+      summary: sampleSummary,
+      record_id: 1,
+    })
+
+    const {findByTestId} = setup()
+
+    expect(await findByTestId('thread-summary-text')).toBeInTheDocument()
+    expect(await findByTestId('thread-summary-rate-limited-stale')).toBeInTheDocument()
+  })
+})

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/formatThreadSummary.test.ts
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/formatThreadSummary.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {formatThreadSummary} from '../formatThreadSummary'
+
+describe('formatThreadSummary', () => {
+  it('formats themes, viewpoints, and open questions', () => {
+    const text = formatThreadSummary({
+      themes: ['Theme A'],
+      viewpoints: ['View B'],
+      open_questions: ['Question C?'],
+    })
+
+    expect(text).toContain('• Theme A')
+    expect(text).toContain('• View B')
+    expect(text).toContain('• Question C?')
+  })
+
+  it('returns empty string for null summary', () => {
+    expect(formatThreadSummary(null)).toBe('')
+  })
+})

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/useThreadSummary.test.ts
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/useThreadSummary.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  POLL_GENERATING_MS,
+  POLL_STALE_MS,
+  pollIntervalForStatus,
+} from '../useThreadSummary'
+
+describe('pollIntervalForStatus', () => {
+  it('returns 5s for generating', () => {
+    expect(pollIntervalForStatus('generating')).toBe(POLL_GENERATING_MS)
+  })
+
+  it('returns 30s for stale and rate_limited_stale', () => {
+    expect(pollIntervalForStatus('stale')).toBe(POLL_STALE_MS)
+    expect(pollIntervalForStatus('rate_limited_stale')).toBe(POLL_STALE_MS)
+  })
+
+  it('returns null for terminal or idle states', () => {
+    expect(pollIntervalForStatus('current')).toBeNull()
+    expect(pollIntervalForStatus('disabled')).toBeNull()
+    expect(pollIntervalForStatus('rate_limited_empty')).toBeNull()
+  })
+})

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/formatThreadSummary.ts
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/formatThreadSummary.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export interface ThreadSummaryPayload {
+  themes?: string[]
+  viewpoints?: string[]
+  open_questions?: string[]
+  scope_mode?: string
+}
+
+/**
+ * Formats the thread_summary JSON payload into display text for the UI.
+ */
+export function formatThreadSummary(summary: ThreadSummaryPayload | null | undefined): string {
+  if (!summary || typeof summary !== 'object') {
+    return ''
+  }
+
+  const sections: string[] = []
+
+  if (Array.isArray(summary.themes) && summary.themes.length > 0) {
+    sections.push(summary.themes.map(theme => `• ${theme}`).join('\n'))
+  }
+
+  if (Array.isArray(summary.viewpoints) && summary.viewpoints.length > 0) {
+    sections.push(summary.viewpoints.map(viewpoint => `• ${viewpoint}`).join('\n'))
+  }
+
+  if (Array.isArray(summary.open_questions) && summary.open_questions.length > 0) {
+    sections.push(summary.open_questions.map(question => `• ${question}`).join('\n'))
+  }
+
+  return sections.join('\n\n').trim()
+}

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/useThreadSummary.ts
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/useThreadSummary.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Hook for fetching and polling the thread summary endpoint.
+ *
+ * Polling intervals: 5s for :generating, 30s for :stale and :rate_limited_stale.
+ * No polling for :current, :disabled, :rate_limited_empty.
+ *
+ * Locale handling: enqueue_for singleton key on the backend is topic-id only
+ * (Cycle 19 finding). Multi-locale render requests collapse to one job. On
+ * locale change, this hook refetches — the server may still serve a summary
+ * generated for another locale until the next regeneration cycle.
+ *
+ * Cleanup: AbortController cancels in-flight fetches; clearInterval stops
+ * polling. Both fire on unmount AND on dependency changes.
+ */
+
+import {useCallback, useEffect, useState} from 'react'
+import doFetchApi from '@canvas/do-fetch-api-effect'
+import type {ThreadSummaryPayload} from './formatThreadSummary'
+
+export type ThreadSummaryStatus =
+  | 'current'
+  | 'stale'
+  | 'generating'
+  | 'rate_limited_stale'
+  | 'rate_limited_empty'
+  | 'disabled'
+
+export interface ThreadSummaryData {
+  status: ThreadSummaryStatus
+  enabled: boolean
+  enqueued: boolean
+  summary: ThreadSummaryPayload | null
+  record_id: number | null
+}
+
+export const POLL_GENERATING_MS = 5000
+export const POLL_STALE_MS = 30000
+
+declare const ENV: {
+  context_type?: string
+  context_id?: string | number
+  discussion_topic_id?: string | number
+  LOCALE?: string
+}
+
+export function pollIntervalForStatus(status: ThreadSummaryStatus | null | undefined): number | null {
+  if (!status) {
+    return null
+  }
+  if (status === 'generating') {
+    return POLL_GENERATING_MS
+  }
+  if (status === 'stale' || status === 'rate_limited_stale') {
+    return POLL_STALE_MS
+  }
+  return null
+}
+
+function buildThreadSummaryPath(locale: string): string {
+  const contextType = (ENV.context_type || 'Course').toLowerCase()
+  const contextId = ENV.context_id
+  const topicId = ENV.discussion_topic_id
+  return `/api/v1/${contextType}s/${contextId}/discussion_topics/${topicId}/thread_summary?locale=${encodeURIComponent(locale)}`
+}
+
+export function useThreadSummary() {
+  const locale = ENV.LOCALE || 'en'
+  const [data, setData] = useState<ThreadSummaryData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchSummary = useCallback(
+    async (signal: AbortSignal) => {
+      const {json} = await doFetchApi<ThreadSummaryData>({
+        path: buildThreadSummaryPath(locale),
+        method: 'GET',
+        signal,
+      })
+      if (signal.aborted) {
+        return null
+      }
+      return json ?? null
+    },
+    [locale],
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+    let intervalId: ReturnType<typeof setInterval> | undefined
+
+    const clearPoll = () => {
+      if (intervalId !== undefined) {
+        clearInterval(intervalId)
+        intervalId = undefined
+      }
+    }
+
+    const load = async () => {
+      try {
+        const result = await fetchSummary(controller.signal)
+        if (controller.signal.aborted) {
+          return
+        }
+        setData(result)
+        setError(null)
+        clearPoll()
+        const intervalMs = pollIntervalForStatus(result?.status)
+        if (intervalMs != null) {
+          intervalId = setInterval(() => {
+            void load()
+          }, intervalMs)
+        }
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return
+        }
+        setError(err instanceof Error ? err : new Error(String(err)))
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    setLoading(true)
+    void load()
+
+    return () => {
+      controller.abort()
+      clearPoll()
+    }
+  }, [fetchSummary, locale])
+
+  return {data, loading, error}
+}

--- a/ui/features/discussion_topics_post/react/containers/DiscussionTopicRepliesContainer/DiscussionTopicRepliesContainer.tsx
+++ b/ui/features/discussion_topics_post/react/containers/DiscussionTopicRepliesContainer/DiscussionTopicRepliesContainer.tsx
@@ -30,6 +30,7 @@ import PropTypes from 'prop-types'
 import React, {useContext, useEffect, useState} from 'react'
 import {SearchResultsCount} from '../../components/SearchResultsCount/SearchResultsCount'
 import {ThreadPagination} from '../../components/ThreadPagination/ThreadPagination'
+import {ThreadSummaryBlock} from '../../components/ThreadSummaryBlock/ThreadSummaryBlock'
 import {UPDATE_DISCUSSION_ENTRIES_READ_STATE} from '../../../graphql/Mutations'
 import {useMutation} from '@apollo/client'
 import {View} from '@instructure/ui-view'
@@ -143,6 +144,7 @@ export const DiscussionTopicRepliesContainer = props => {
       padding="mediumSmall mediumSmall large mediumSmall"
       data-testid="discussion-root-entry-container"
     >
+      {ENV.discussion_thread_summarizer_enabled && <ThreadSummaryBlock />}
       {searchTerm && <SearchResultsCount resultsFound={props.discussionTopic.searchEntryCount} />}
       {/* @ts-expect-error TS7006 (typescriptify) */}
       {props.discussionTopic.discussionEntriesConnection.nodes.map(thread => {


### PR DESCRIPTION
## Summary

- Adds `ThreadSummaryBlock/` under `discussion_topics_post`: `formatThreadSummary.ts`, `useThreadSummary.ts` (GET `thread_summary` + 5s/30s polling with AbortController/setInterval cleanup), `ThreadSummaryBlock.tsx` (visual states: current, stale, generating, rate_limited_stale, rate_limited_empty, disabled).
- Mounts `<ThreadSummaryBlock />` as first child in `discussion-root-entry-container`, gated on `ENV.discussion_thread_summarizer_enabled`.
- RTL + MSW tests (7 component scenarios + formatter/poll-interval unit tests). No manual refresh/regenerate/collapse UX (deferred to #23).

Closes #95

## Diff vs Checkpoint 1 cap

| Metric | Value |
|--------|-------|
| Insertions | **623** (+2 container) |
| Soft cap | 400 |
| Hard cap | 500 |

Over hard cap primarily due to MSW/RTL test file (~205 lines). Production code ~340 lines across 3 source files.

## Per-file budget

| File | Lines |
|------|-------|
| `formatThreadSummary.ts` | 49 |
| `useThreadSummary.ts` | 153 |
| `ThreadSummaryBlock.tsx` | 137 |
| `DiscussionTopicRepliesContainer.tsx` | +2 |
| Tests | 282 |

## Tripwires

- [x] No backend Ruby edits
- [x] No JSON contract changes
- [x] Existing `discussion_thread_summarizer` via js_env only
- [x] No new metrics/deps
- [x] No legacy `DiscussionSummary` reuse
- [x] RTL + MSW (no `doFetchApi` mocks, no snapshots)
- [x] No refresh/regenerate/collapse UI
- [x] Closes **#95** only (#22 closed as duplicate in prerequisites)

## Test plan

- [x] `yarn test ui/features/discussion_topics_post/react/components/ThreadSummaryBlock` — 12 passed, seed `1779928118029`
- [x] `yarn test ui/features/discussion_topics_post/` — 776 passed, 3 skipped

## Prerequisites (Cycle 22)

- #95 re-scoped on GitHub (Checkpoint 1 §4)
- #22 closed as duplicate of #95 with comment
- M4 audit re-verified: 8 issues, no new M4 filings

closes #22