### PR TITLE
[M4][Cycle 23] Gate-proof tests: must-post-before-replies on thread_summary (#24, #26)

### DIFF
--- a/spec/controllers/discussion_topics_api_controller_spec.rb
+++ b/spec/controllers/discussion_topics_api_controller_spec.rb
@@ -1361,10 +1361,11 @@ describe DiscussionTopicsApiController do
 
   context "thread_summary (Discussion Thread Summarizer)" do
     before do
-      course_with_student(active_all: true)
+      course_with_teacher(active_all: true)
+      student_in_course(active_all: true, course: @course)
       @course.enable_feature!(:discussion_thread_summarizer)
-      @topic = @course.discussion_topics.create!(title: "discussion")
-      @topic.discussion_entries.create!(user: @student, message: "hello")
+      @topic = @course.discussion_topics.create!(title: "discussion", user: @teacher)
+      @topic.discussion_entries.create!(user: @teacher, message: "hello")
       user_session(@student)
       allow(Canvas).to receive(:redis_enabled?).and_return(true)
       allow(Canvas.redis).to receive(:get).and_return(nil)
@@ -1420,6 +1421,47 @@ describe DiscussionTopicsApiController do
       expect(body["status"]).to eq("generating")
       expect(body["enqueued"]).to be(true)
       expect(body["summary"]).to be_nil
+    end
+
+    it "returns require_initial_post and does not enqueue when the viewer has not posted" do
+      @topic.update!(require_initial_post: true)
+
+      expect do
+        get "thread_summary",
+            params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+            format: "json"
+      end.not_to change { Delayed::Job.count }
+
+      expect(response).to have_http_status :forbidden
+      expect(response.body).to eq "require_initial_post"
+    end
+
+    it "returns unauthorized and does not enqueue when the viewer has no :read access" do
+      outsider = user_factory(active_all: true)
+      user_session(outsider)
+
+      expect do
+        get "thread_summary",
+            params: { topic_id: @topic.id, course_id: @course.id, user_id: outsider.id },
+            format: "json"
+      end.not_to change { Delayed::Job.count }
+
+      expect(response).to have_http_status :forbidden
+      expect(response.parsed_body["status"]).to eq("unauthorized")
+    end
+
+    it "returns normal summary generation/enqueue for a posted, readable viewer" do
+      # ensure the student has posted so initial-post gate won't block
+      @topic.discussion_entries.create!(user: @student, message: "student message")
+
+      expect do
+        get "thread_summary",
+            params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+            format: "json"
+      end.to change { Delayed::Job.count }.by_at_least(0)
+
+      body = response.parsed_body
+      expect(["generating", "current", "disabled"]).to include(body["status"]) if body
     end
   end
 end

--- a/spec/controllers/discussion_topics_api_controller_spec.rb
+++ b/spec/controllers/discussion_topics_api_controller_spec.rb
@@ -1461,7 +1461,8 @@ describe DiscussionTopicsApiController do
       end.to change { Delayed::Job.count }.by_at_least(0)
 
       body = response.parsed_body
-      expect(["generating", "current", "disabled"]).to include(body["status"]) if body
+      expect(body).to be_present
+      expect(body["status"]).to(satisfy { |s| %w[generating current disabled].include?(s) })
     end
   end
 end

--- a/spec/controllers/discussion_topics_api_controller_spec.rb
+++ b/spec/controllers/discussion_topics_api_controller_spec.rb
@@ -1451,18 +1451,21 @@ describe DiscussionTopicsApiController do
     end
 
     it "returns normal summary generation/enqueue for a posted, readable viewer" do
-      # ensure the student has posted so initial-post gate won't block
+      @topic.update!(require_initial_post: true)
+
+      # satisfy the must-post-first gate for this viewer
       @topic.discussion_entries.create!(user: @student, message: "student message")
 
       expect do
         get "thread_summary",
             params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
             format: "json"
-      end.to change { Delayed::Job.count }.by_at_least(0)
+      end.to change { Delayed::Job.count }.by(1)
 
       body = response.parsed_body
+      expect(response).not_to have_http_status(:forbidden)
       expect(body).to be_present
-      expect(body["status"]).to(satisfy { |s| %w[generating current disabled].include?(s) })
+      expect(body["status"]).to eq("generating")
     end
   end
 end

--- a/spec/graphql/types/discussion_type_spec.rb
+++ b/spec/graphql/types/discussion_type_spec.rb
@@ -191,6 +191,16 @@ RSpec.shared_examples "DiscussionType" do
     expect(type_with_student.resolve("discussionEntriesConnection { nodes { message } }").count).to eq 2
   end
 
+  it "returns participant summaryEnabled as a preference flag" do
+    participant = discussion.update_or_create_participant(current_user: @teacher)
+
+    participant.update!(summary_enabled: true)
+    expect(discussion_type.resolve("participant { summaryEnabled }")).to be true
+
+    participant.update!(summary_enabled: false)
+    expect(discussion_type.resolve("participant { summaryEnabled }")).to be false
+  end
+
   it "allows querying for entry counts" do
     3.times { discussion.discussion_entries.create!(message: "sub entry", user: @teacher) }
     discussion.discussion_entries.take.destroy


### PR DESCRIPTION
## Summary
This PR adds gate-proof tests for `thread_summary` in Cycle 23 and documents the accepted contract decision.

Contract decision on record (D3):
- Must-post-first gate responds with HTTP 403 and body `require_initial_post`.
- AC wording "returns null" is satisfied in spirit by gate behavior: no summary content is surfaced and no generation job is enqueued.

## Test Coverage
1. Baseline no-summary path enqueues and returns generating
   - `spec/controllers/discussion_topics_api_controller_spec.rb:1413`
2. Must-post gate blocked path: 403 + `require_initial_post` + no enqueue
   - `spec/controllers/discussion_topics_api_controller_spec.rb:1426`
3. No-read path: forbidden + `status: unauthorized` + no enqueue
   - `spec/controllers/discussion_topics_api_controller_spec.rb:1439`
4. Must-post gate satisfied path: `require_initial_post: true` + viewer posted => not forbidden, enqueues 1, status `generating`
   - `spec/controllers/discussion_topics_api_controller_spec.rb:1453`
5. GraphQL defensive guard: participant `summaryEnabled` remains a preference flag (shared examples run for course and group discussions)
   - `spec/graphql/types/discussion_type_spec.rb:194`

## Full-file Runs
- `spec/controllers/discussion_topics_api_controller_spec.rb`: 83 examples, 0 failures, 2 pending
- `spec/graphql/types/discussion_type_spec.rb`: 137 examples, 0 failures

## Diff Size
- `2 files changed, 59 insertions(+), 3 deletions(-)`

closes #24
closes #26