### PR TITLE
[M4][Cycle 23] Evidence: gate-proof verification for thread_summary (#24, #26)

### DIFF
--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -815,3 +815,19 @@ When flag off, `#fetch_or_create_summary` returns `CacheResult.new(status: :rate
 | Evidence completion | [#108](https://github.com/ejgdr/canvas-lms/pull/108) | (squash-merge SHA) | (squash-merge timestamp) |
 
 *Last verified: 2026-05-28 against squash-merge f2cd7a220c01d3b51900eafd9515833228d606be (evidence records); impl row remains `186a92f5e4231065a29f187e805d128eb30b6dcf`.*
+
+---
+
+## Cycle 23 implementation evidence
+
+| Step | PR | SHA / notes | Timestamp (UTC) |
+|------|----|-------------|-----------------|
+| Implementation | [#109](https://github.com/ejgdr/canvas-lms/pull/109) | `9bde31884ce686ac45634e36a62ea4591ad4008d` | 2026-05-29 |
+| Contract decision | D3 recorded in PR body | 403 / `require_initial_post` is the accepted gate contract; AC "returns null" satisfied in spirit by no content, no job | 2026-05-29 |
+| Controller gate proof | [spec/controllers/discussion_topics_api_controller_spec.rb](../../../spec/controllers/discussion_topics_api_controller_spec.rb#L1413) | 4 cases: generating/no summary; 403 blocked must-post; forbidden no-read; generating when gate satisfied | 2026-05-29 |
+| GraphQL guard | [spec/graphql/types/discussion_type_spec.rb](../../../spec/graphql/types/discussion_type_spec.rb#L194) | participant `summaryEnabled` remains a preference flag in shared examples for course + group discussions | 2026-05-29 |
+| Full-file runs | `spec/controllers/discussion_topics_api_controller_spec.rb`; `spec/graphql/types/discussion_type_spec.rb` | 83 examples, 0 failures, 2 pending; 137 examples, 0 failures | 2026-05-29 |
+| RuboCop | changed Ruby specs | 2 files inspected, no offenses detected | 2026-05-29 |
+| Diff size | branch diff vs `master` | 2 files changed, 59 insertions(+), 3 deletions(-) | 2026-05-29 |
+
+*Last verified (Cycle 23 row): 2026-05-29 against branch SHA `9bde31884ce686ac45634e36a62ea4591ad4008d`*


### PR DESCRIPTION
## Summary
Cycle 23 evidence record for the thread_summary gate-proof slice. This PR is docs-only and captures the verification trail for PR #109.

Contract decision on record (D3):
- Must-post-first gate responds with HTTP 403 and body `require_initial_post`.
- AC wording "returns null" is satisfied in spirit by gate behavior: no summary content is surfaced and no generation job is enqueued.

## Verification Evidence
- Controller gate proof and full four-case matrix: `agents/tasks/feature-1/implementation-evidence.md` Cycle 23 row
- GraphQL preference guard: `spec/graphql/types/discussion_type_spec.rb:194`
- Full-file runs: 83 examples, 0 failures, 2 pending; 137 examples, 0 failures
- RuboCop: 2 files inspected, no offenses detected
- Diff size: 2 files changed, 59 insertions(+), 3 deletions(-)

## References
- Implementation PR: #109
- Issues: #24, #26

## Notes
- The cycle evidence row is stamped against branch SHA `9bde31884ce686ac45634e36a62ea4591ad4008d`.
- No board transition or QA status change is included in this PR; that remains for the completion PR.