### PR TITLE
docs(evidence): record Cycle 24 (#21 additive summary fields)

### DIFF
--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -845,3 +845,21 @@ When flag off, `#fetch_or_create_summary` returns `CacheResult.new(status: :rate
 | Diff size | branch diff vs `master` | 2 files changed, 59 insertions(+), 3 deletions(-) | 2026-05-29 |
 
 *Last verified (Cycle 23 row): 2026-05-29 against branch SHA `9bde31884ce686ac45634e36a62ea4591ad4008d`*
+
+---
+
+## Cycle 24 — Additive summary fields on DiscussionTopic REST + GraphQL (issue #21)
+
+| Field | Content |
+|---|---|
+| Cycle | 24 |
+| Issue | [#21](https://github.com/ejgdr/canvas-lms/issues/21) — additive summary fields on DiscussionTopic REST + GraphQL |
+| Implementation PR | [#112](https://github.com/ejgdr/canvas-lms/pull/112), branch `feat/m4-topic-summary-embed`, squash-merge SHA `132427903290b7c65b81a947daa2965e0f0c4ed9` (2026-05-30T20:06:56Z) |
+| What shipped | `DiscussionThreadSummarizer::TopicSummaryEmbed`; REST `show` + `view` additive `summary` object; GraphQL `Discussion.summary` + `DiscussionThreadSummary` type + `DiscussionThreadSummaryStatus` enum; [API doc](../../../doc/discussion_thread_summarizer_api_embed.md) |
+| Contract decision | `status` ∈ {`current`, `stale`, `generating`, `unavailable`}; `summary` is `null` only when no cache row exists **and** generation has not started (`rate_limited_empty` → `null`). `:generating` returns an object with `status: "generating"`, `text: nil`, `generated_at: nil`. |
+| Diff size | **465 lines** (+464 / −1); **196 lines** in controller spec alone — over 250 hard cap; justified as cohesive additive REST + GraphQL + type + module + tests unit (Cycle 17 precedent) |
+| Test evidence | **16 examples, 0 failures**, seed `63338` (~18.14 s). Matrix: {show, view, GraphQL} × {flag off + shape stability, cached current/stale, generating object, not started (`rate_limited_empty` → null)} |
+| Reproduce command | `docker compose exec web bundle exec rspec spec/controllers/discussion_topics_api_controller_spec.rb -e "thread summary embed" spec/graphql/types/discussion_type_spec.rb -e "thread summary embed"` |
+| QA lab | [qa-lab-evidence.md Cycle 24 row](./qa-lab-evidence.md#cycle-24--additive-summary-fields-issue-21) — `Pass`; board QA Status deferred to completion PR |
+
+*Last verified (Cycle 24 row): 2026-05-30T20:07:30Z against squash-merge `132427903290b7c65b81a947daa2965e0f0c4ed9`*

--- a/agents/tasks/feature-1/qa-lab-evidence.md
+++ b/agents/tasks/feature-1/qa-lab-evidence.md
@@ -394,4 +394,40 @@ The first closed slice (issue #1, PR #54) merged before this workflow was introd
 
 ---
 
+## Cycle 24 — Additive summary fields (issue #21)
+
+| Field | Content |
+|---|---|
+| Slice | [#21](https://github.com/ejgdr/canvas-lms/issues/21) — additive `summary` on DiscussionTopic REST `show`/`view` and GraphQL `Discussion.summary`. Branch `feat/m4-topic-summary-embed`. |
+| Classification | Behavior-changing application code — Ruby REST/GraphQL embed wiring + controller/GraphQL specs. |
+| Tests added / extended | `spec/controllers/discussion_topics_api_controller_spec.rb` (`thread summary embed on show`, `thread summary embed on view`); `spec/graphql/types/discussion_type_spec.rb` (`thread summary embed`). |
+| Command (targeted) | `docker compose exec web bundle exec rspec spec/controllers/discussion_topics_api_controller_spec.rb -e "thread summary embed" spec/graphql/types/discussion_type_spec.rb -e "thread summary embed"` |
+| Outcome (targeted) | **16 examples, 0 failures** (~18.14 s, seed `63338`). |
+| Matrix covered | REST show/view + GraphQL: flag off (omit key / null + shape stability); cached `current`/`stale`; `generating` object; not started (`rate_limited_empty` → null, no job). |
+| `QA Status` | `Pass` (recorded here; board field update deferred to Cycle 24 completion PR) |
+| PR / commit | [PR #112](https://github.com/ejgdr/canvas-lms/pull/112), squash-merged at `132427903290b7c65b81a947daa2965e0f0c4ed9` on 2026-05-30T20:06:56Z |
+| Trace to plan | FR embed on topic payload; reuses `discussion_thread_summarizer` flag and `SummarizationService#lookup_for_render`. |
+
+*Last verified (Cycle 24 row): 2026-05-30T20:07:30Z against squash-merge `132427903290b7c65b81a947daa2965e0f0c4ed9`*
+
+---
+
 *Last verified: 2026-05-28 against squash-merge 186a92f5e4231065a29f187e805d128eb30b6dcf*
+
+---
+
+## Cycle 24 — Additive summary fields (issue #21)
+
+| Field | Content |
+|---|---|
+| Slice | [#21](https://github.com/ejgdr/canvas-lms/issues/21) — additive `summary` on DiscussionTopic REST `show`/`view` and GraphQL `Discussion.summary`. Branch `feat/m4-topic-summary-embed`. |
+| Classification | Behavior-changing application code — Ruby REST/GraphQL embed wiring + controller/GraphQL specs. |
+| Tests added / extended | `spec/controllers/discussion_topics_api_controller_spec.rb` (`thread summary embed on show`, `thread summary embed on view`); `spec/graphql/types/discussion_type_spec.rb` (`thread summary embed`). |
+| Command (targeted) | `docker compose exec web bundle exec rspec spec/controllers/discussion_topics_api_controller_spec.rb -e "thread summary embed" spec/graphql/types/discussion_type_spec.rb -e "thread summary embed"` |
+| Outcome (targeted) | **16 examples, 0 failures** (~18.14 s, seed `63338`). |
+| Matrix covered | REST show/view + GraphQL: flag off (omit key / null + shape stability); cached `current`/`stale`; `generating` object; not started (`rate_limited_empty` → null, no job). |
+| `QA Status` | `Pass` (recorded here; board field update deferred to Cycle 24 completion PR) |
+| PR / commit | [PR #112](https://github.com/ejgdr/canvas-lms/pull/112), squash-merged at `132427903290b7c65b81a947daa2965e0f0c4ed9` on 2026-05-30T20:06:56Z |
+| Trace to plan | FR embed on topic payload; reuses `discussion_thread_summarizer` flag and `SummarizationService#lookup_for_render`. |
+
+*Last verified (Cycle 24 row): 2026-05-30T20:07:30Z against squash-merge `132427903290b7c65b81a947daa2965e0f0c4ed9`*


### PR DESCRIPTION
## Summary

Cycle 24 evidence row for issue #21 (additive summary fields on DiscussionTopic REST + GraphQL), implementation PR #112.

- **Implementation merge SHA:** `132427903290b7c65b81a947daa2965e0f0c4ed9`
- **Contract on record:** `status` ∈ {current, stale, generating, unavailable}; `summary` null only when no cache and generation not started; `generating` returns object with `status: "generating"`.
- **QA gate:** 16 examples, 0 failures (seed `63338`); matrix documented in both evidence files.
- **Board:** #21 remains In Progress; completion PR will set Status = Done and QA Status = Pass.

## Test plan

- [x] Evidence-only diff (no source/spec changes)
- [x] Targeted rspec reproduce command recorded and run green against merge SHA

refs #21
flag=none

Made with [Cursor](https://cursor.com)