### PR TITLE
feat(summarizer): wire generation latency metrics (#27)

### DIFF
--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -102,6 +102,8 @@ module DiscussionThreadSummarizer
       end
 
       DiscussionThreadSummarizer::Metrics.increment_rate_limit_allowed(account:)
+      scope_mode = scope_mode_for(discussion_topic)
+      DiscussionThreadSummarizer::Metrics.increment_generation_attempt(account:, scope_mode:)
       result = summarize(discussion_topic:, viewer:)
       record = persist_summary_record(
         discussion_topic:,
@@ -160,18 +162,27 @@ module DiscussionThreadSummarizer
 
     def summarize(discussion_topic:, viewer:)
       account = discussion_topic.context.root_account
+      scope_mode = scope_mode_for(discussion_topic)
       payload = gather(discussion_topic, viewer)
       payload = pseudonymize(payload)
-      t0      = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       result = @client.summarize(payload)
       begin
         validate(result)
       rescue DiscussionThreadSummarizer::SchemaViolationError
+        Metrics.increment_generation_error(account:, scope_mode:)
         Metrics.increment_failure(reason: "schema_invalid", account:)
         raise
       end
+      latency_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000).round
+      Metrics.record_generation_latency_ms(duration_ms: latency_ms, account:, scope_mode:)
       result
+    rescue StandardError => e
+      unless e.is_a?(DiscussionThreadSummarizer::SchemaViolationError)
+        Metrics.increment_generation_error(account:, scope_mode:)
+      end
+      raise
     ensure
       if t0
         propagating = $!
@@ -265,7 +276,7 @@ module DiscussionThreadSummarizer
       scope_limited = course.root_account.feature_enabled?(
         :discussion_thread_summarizer_scope_limited
       )
-      scope_mode    = scope_limited ? "limited" : "default"
+      scope_mode    = scope_mode_for(discussion_topic, scope_limited:)
 
       raw_entries = discussion_topic.discussion_entries
                                     .active
@@ -286,6 +297,14 @@ module DiscussionThreadSummarizer
                         body:        entry.message || "" }
                     end
       }
+    end
+
+    def scope_mode_for(discussion_topic, scope_limited: nil)
+      scope_limited = discussion_topic.context.root_account.feature_enabled?(
+        :discussion_thread_summarizer_scope_limited
+      ) if scope_limited.nil?
+
+      scope_limited ? "limited" : "default"
     end
 
     def instructor_user_ids(course)

--- a/doc/discussion_thread_summarizer_observability.md
+++ b/doc/discussion_thread_summarizer_observability.md
@@ -1,3 +1,7 @@
 # Discussion Thread Summarizer — observability (M3)
 
 Cycle 20 completes the NFR-4 `cache.*` metric family alongside existing `render.*` (render-state) and `invalidation.*` (write-side) families. These are **parallel telemetry paths**, not aliases: stale summary serve dual-emits `render.stale` and `cache.stale`; invalidation dual-emits `invalidation.fired` and `cache.invalidated` (with `trigger:` `reply_create` / `reply_edit` / `reply_delete`). Stale-to-fresh ratio dashboards are tracked in issue #50.
+
+## Generation latency (M4)
+
+When the `discussion_thread_summarizer` course feature is enabled, completed background generations emit InstStatsd timing on `discussion_thread_summarizer.generation_latency_ms` (tags: `account_id`, `scope_mode`). Attempts and failures increment `discussion_thread_summarizer.generation_attempt` and `discussion_thread_summarizer.generation_error` respectively. Latency measures wall-clock from `@client.summarize` through schema validation only — not cache lookup or rate-limiter probes. Cache hits and rate-limiter short-circuits do not emit generation metrics.

--- a/lib/discussion_thread_summarizer/metrics.rb
+++ b/lib/discussion_thread_summarizer/metrics.rb
@@ -27,21 +27,29 @@ module DiscussionThreadSummarizer
   module Metrics
     PREFIX = "discussion_thread_summarizer"
 
-    # Emitted each time a generation is attempted, regardless of outcome.
+    # Emitted each time a generation is attempted (cache miss + rate limit pass).
     def self.increment_generation_attempt(account:, scope_mode:)
       InstStatsd::Statsd.distributed_increment(
-        "#{PREFIX}.generation.attempt",
+        "#{PREFIX}.generation_attempt",
         tags: { account_id: account.global_id, scope_mode: }
       )
     end
 
-    # Records end-to-end generation latency in milliseconds.
-    # outcome: one of "success", "error", "timeout", "schema_invalid"
-    def self.record_generation_latency(duration_ms:, account:, outcome:)
+    # Records model-generation latency in milliseconds for completed jobs only.
+    # Tagged for p50/p95/p99 rollups — no PII.
+    def self.record_generation_latency_ms(duration_ms:, account:, scope_mode:)
       InstStatsd::Statsd.timing(
-        "#{PREFIX}.generation.latency",
+        "#{PREFIX}.generation_latency_ms",
         duration_ms,
-        tags: { account_id: account.global_id, outcome: }
+        tags: { account_id: account.global_id, scope_mode: }
+      )
+    end
+
+    # Emitted when a generation attempt fails before completing successfully.
+    def self.increment_generation_error(account:, scope_mode:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.generation_error",
+        tags: { account_id: account.global_id, scope_mode: }
       )
     end
 

--- a/spec/lib/discussion_thread_summarizer/metrics_spec.rb
+++ b/spec/lib/discussion_thread_summarizer/metrics_spec.rb
@@ -26,22 +26,32 @@ describe DiscussionThreadSummarizer::Metrics do
   end
 
   describe ".increment_generation_attempt" do
-    it "emits discussion_thread_summarizer.generation.attempt with account_id and scope_mode tags" do
+    it "emits discussion_thread_summarizer.generation_attempt with account_id and scope_mode tags" do
       described_class.increment_generation_attempt(account:, scope_mode: "default")
       expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
-        "discussion_thread_summarizer.generation.attempt",
+        "discussion_thread_summarizer.generation_attempt",
         tags: { account_id: 10_000_000_000_001, scope_mode: "default" }
       )
     end
   end
 
-  describe ".record_generation_latency" do
-    it "emits discussion_thread_summarizer.generation.latency with duration, account_id, and outcome tags" do
-      described_class.record_generation_latency(duration_ms: 342, account:, outcome: "success")
+  describe ".record_generation_latency_ms" do
+    it "emits discussion_thread_summarizer.generation_latency_ms with duration, account_id, and scope_mode tags" do
+      described_class.record_generation_latency_ms(duration_ms: 342, account:, scope_mode: "limited")
       expect(InstStatsd::Statsd).to have_received(:timing).with(
-        "discussion_thread_summarizer.generation.latency",
+        "discussion_thread_summarizer.generation_latency_ms",
         342,
-        tags: { account_id: 10_000_000_000_001, outcome: "success" }
+        tags: { account_id: 10_000_000_000_001, scope_mode: "limited" }
+      )
+    end
+  end
+
+  describe ".increment_generation_error" do
+    it "emits discussion_thread_summarizer.generation_error with account_id and scope_mode tags" do
+      described_class.increment_generation_error(account:, scope_mode: "default")
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.generation_error",
+        tags: { account_id: 10_000_000_000_001, scope_mode: "default" }
       )
     end
   end

--- a/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
+++ b/spec/services/discussion_thread_summarizer/summarization_service_spec.rb
@@ -259,6 +259,7 @@ describe DiscussionThreadSummarizer::SummarizationService do
 
     it "emits failure metric with reason 'schema_invalid' before re-raising" do
       allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_failure)
+      allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_generation_error)
       svc = described_class.new(client: malformed_client)
 
       expect { svc.summarize(discussion_topic: topic, viewer:) }
@@ -267,6 +268,10 @@ describe DiscussionThreadSummarizer::SummarizationService do
       expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_failure).with(
         reason:  "schema_invalid",
         account: root_account
+      )
+      expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_generation_error).with(
+        account: root_account,
+        scope_mode: "default"
       )
     end
   end
@@ -646,6 +651,76 @@ describe "DiscussionThreadSummarizer::SummarizationService#fetch_or_create_summa
       expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_rate_limit_allowed)
         .with(account: course.root_account)
       expect(stub_client).to have_received(:summarize).once
+    end
+  end
+
+  context "generation latency metrics (#27)" do
+    let(:account) { course.root_account }
+
+    before do
+      allow(Canvas).to receive(:redis_enabled?).and_return(true)
+      allow(DiscussionThreadSummarizer::RegenerationRateLimiter).to receive(:check).and_return(:allowed)
+      allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_generation_attempt)
+      allow(DiscussionThreadSummarizer::Metrics).to receive(:record_generation_latency_ms)
+      allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_generation_error)
+    end
+
+    it "emits generation_attempt and generation_latency_ms on a completed cache-miss job" do
+      service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+      expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_generation_attempt).with(
+        account:,
+        scope_mode: "default"
+      )
+      expect(DiscussionThreadSummarizer::Metrics).to have_received(:record_generation_latency_ms).with(
+        hash_including(account:, scope_mode: "default", duration_ms: kind_of(Integer))
+      )
+      expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_generation_error)
+    end
+
+    it "does not emit generation_attempt or generation_latency_ms on a cache hit" do
+      seed_summary
+
+      service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+      expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_generation_attempt)
+      expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:record_generation_latency_ms)
+      expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_generation_error)
+    end
+
+    it "does not emit generation_attempt or generation_latency_ms when the rate limiter denies" do
+      allow(DiscussionThreadSummarizer::RegenerationRateLimiter).to receive(:check)
+        .and_return(:cooldown_denied)
+      allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_rate_limit_cooldown_denied)
+
+      service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+
+      expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_generation_attempt)
+      expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:record_generation_latency_ms)
+      expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:increment_generation_error)
+    end
+
+    it "emits generation_error without generation_latency_ms when generation fails" do
+      malformed = Class.new(DiscussionThreadSummarizer::ModelClient) do
+        def summarize(_payload)
+          { themes: [], viewpoints: [], open_questions: [] }
+        end
+      end.new
+      failing_service = DiscussionThreadSummarizer::SummarizationService.new(client: malformed)
+
+      expect do
+        failing_service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale:)
+      end.to raise_error(DiscussionThreadSummarizer::SchemaViolationError)
+
+      expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_generation_attempt).with(
+        account:,
+        scope_mode: "default"
+      )
+      expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_generation_error).with(
+        account:,
+        scope_mode: "default"
+      )
+      expect(DiscussionThreadSummarizer::Metrics).not_to have_received(:record_generation_latency_ms)
     end
   end
 end


### PR DESCRIPTION
## Summary
Wire NFR-4 generation observability from the async summarization job path: `generation_attempt`, `generation_latency_ms`, and `generation_error` InstStatsd metrics via existing `DiscussionThreadSummarizer::Metrics` helpers.

## Measurement boundary
Latency wraps `@client.summarize` + schema validation only (monotonic clock from existing audit-log `t0`). Excludes gather/pseudonymize, cache lookup, and rate-limiter probes.

## Scope
- Backend-only; no UI changes
- Cache hits and rate-limiter short-circuits do not emit generation metrics
- Tags: `account_id`, `scope_mode` on all three metrics (no PII)
- Release note in `doc/discussion_thread_summarizer_observability.md`

Closes #27

NFR-4 — Generation latency (p50, p95, p99)
M4 — Per-thread summary surface (observability story)

## Verification
- `docker compose run --rm web bin/rspec spec/lib/discussion_thread_summarizer/metrics_spec.rb` — **11 examples, 0 failures**
- `docker compose run --rm web bin/rspec spec/services/discussion_thread_summarizer/summarization_service_spec.rb -e "generation latency metrics"` — **4 examples, 0 failures**
- `git diff --stat origin/master...HEAD` — source + specs + release-note doc only

## QA
See qa-lab-evidence.md Cycle 26 row (evidence PR to follow).


Made with [Cursor](https://cursor.com)