### PR TITLE
[M4][Cycle 27] Regenerate + cooldown UX (#23) + backend regenerate endpoint (#121)

### DIFF
--- a/app/controllers/discussion_topics_api_controller.rb
+++ b/app/controllers/discussion_topics_api_controller.rb
@@ -157,6 +157,52 @@ class DiscussionTopicsApiController < ApplicationController
     render(json: thread_summary_json(result))
   end
 
+  # @API Regenerate thread summary (Discussion Thread Summarizer)
+  #
+  # Enqueues a background regeneration job when cooldown and daily quota allow.
+  # Returns 429 with retry_after_seconds when the per-user per-thread cooldown
+  # is active, or a quota_exhausted error when the account daily budget is spent.
+  #
+  # @example_request
+  #
+  #     curl https://<canvas>/api/v1/courses/<course_id>/discussion_topics/<topic_id>/thread_summary/regenerate \
+  #         -X POST \
+  #         -H 'Authorization: Bearer <token>'
+  def regenerate_thread_summary
+    result = DiscussionThreadSummarizer::SummarizationService.new.request_regenerate(
+      discussion_topic: @topic,
+      viewer: @current_user,
+      locale: I18n.locale.to_s
+    )
+
+    case result.status
+    when :generating
+      render(json: { status: "generating", enqueued: true })
+    when :cooldown_denied
+      render(
+        json: {
+          error: "cooldown",
+          retry_after_seconds: result.retry_after_seconds ||
+            Setting.get(
+              DiscussionThreadSummarizer::RegenerationRateLimiter::COOLDOWN_SETTING_KEY,
+              DiscussionThreadSummarizer::RegenerationRateLimiter::DEFAULT_COOLDOWN_SECONDS
+            ).to_i
+        },
+        status: :too_many_requests
+      )
+    when :quota_denied
+      render(
+        json: {
+          error: "quota_exhausted",
+          message: t("Daily regeneration limit reached. Try again later.")
+        },
+        status: :too_many_requests
+      )
+    when :disabled
+      render(json: { status: "disabled", enabled: false, enqueued: false })
+    end
+  end
+
   # @API Find or Create Summary
   #
   # Generates a summary for a discussion topic. Returns the summary text and usage information.
@@ -1378,13 +1424,41 @@ class DiscussionTopicsApiController < ApplicationController
       return { status: "disabled", enabled: false, enqueued: false }
     end
 
-    {
+    payload = {
       status: result.status.to_s,
       enabled: true,
       enqueued: result.enqueued,
       summary: result.result,
-      record_id: result.record&.id
+      record_id: result.record&.id,
+      regeneration: thread_summary_regeneration_json
     }
+    payload
+  end
+
+  def thread_summary_regeneration_json
+    account = @topic.context.root_account
+    case DiscussionThreadSummarizer::RegenerationRateLimiter.preview(
+      account:,
+      user: @current_user,
+      discussion_topic: @topic
+    )
+    when :allowed
+      { available: true }
+    when :cooldown_denied
+      {
+        available: false,
+        reason: "cooldown",
+        retry_after_seconds: DiscussionThreadSummarizer::RegenerationRateLimiter.cooldown_remaining_seconds(
+          user: @current_user,
+          discussion_topic: @topic
+        ) || Setting.get(
+          DiscussionThreadSummarizer::RegenerationRateLimiter::COOLDOWN_SETTING_KEY,
+          DiscussionThreadSummarizer::RegenerationRateLimiter::DEFAULT_COOLDOWN_SECONDS
+        ).to_i
+      }
+    when :quota_denied
+      { available: false, reason: "quota_exhausted" }
+    end
   end
 
   def fetch_or_create_summary(llm_config:, dynamic_content:, dynamic_content_hash:, user_input:, parent_summary: nil, locale: nil)

--- a/app/services/discussion_thread_summarizer/regeneration_rate_limiter.rb
+++ b/app/services/discussion_thread_summarizer/regeneration_rate_limiter.rb
@@ -85,6 +85,13 @@ module DiscussionThreadSummarizer
     end
     private_class_method :acquire_quota
 
+    def self.cooldown_remaining_seconds(user:, discussion_topic:)
+      raise REDIS_REQUIRED_MESSAGE unless Canvas.redis_enabled?
+
+      ttl = Canvas.redis.ttl(cooldown_key(user, discussion_topic))
+      ttl.positive? ? ttl : nil
+    end
+
     def self.cooldown_key(user, discussion_topic)
       ["discussion_thread_summarizer", "cooldown", user.id, discussion_topic.id].cache_key
     end

--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -39,6 +39,7 @@ module DiscussionThreadSummarizer
     ].freeze
 
     RenderResult = Struct.new(:status, :record, :result, :enqueued, keyword_init: true)
+    RegenerateResult = Struct.new(:status, :retry_after_seconds, :enqueued, keyword_init: true)
 
     # Enqueues a background summary attempt via Delayed Job.
     # Mirrors the insight_generation pattern in DiscussionTopicsApiController.
@@ -113,6 +114,35 @@ module DiscussionThreadSummarizer
         result:
       )
       CacheResult.new(status: :miss, record: record, result: result)
+    end
+
+    # Manual regeneration entrypoint: consumes cooldown/quota budget via .check,
+    # then enqueues a background job. Does not block on generation.
+    def request_regenerate(discussion_topic:, viewer:, locale: I18n.locale.to_s)
+      course = discussion_topic.context
+      unless course.is_a?(Course) && course.feature_enabled?(:discussion_thread_summarizer)
+        return RegenerateResult.new(status: :disabled)
+      end
+
+      account = course.root_account
+      case RegenerationRateLimiter.check(account:, user: viewer, discussion_topic:)
+      when :cooldown_denied
+        DiscussionThreadSummarizer::Metrics.increment_rate_limit_cooldown_denied(account:)
+        return RegenerateResult.new(
+          status: :cooldown_denied,
+          retry_after_seconds: RegenerationRateLimiter.cooldown_remaining_seconds(
+            user: viewer,
+            discussion_topic:
+          )
+        )
+      when :quota_denied
+        DiscussionThreadSummarizer::Metrics.increment_rate_limit_quota_denied(account:)
+        return RegenerateResult.new(status: :quota_denied)
+      end
+
+      DiscussionThreadSummarizer::Metrics.increment_rate_limit_allowed(account:)
+      self.class.enqueue_for(discussion_topic:, viewer:)
+      RegenerateResult.new(status: :generating, enqueued: true)
     end
 
     # Render-time lookup: read-only with respect to the model and rate-limit budget.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1640,6 +1640,7 @@ CanvasRails::Application.routes.draw do
 
         get "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/view", action: :view, as: "#{context}_discussion_topic_view"
         get "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/thread_summary", action: :thread_summary, as: "#{context}_discussion_topic_thread_summary"
+        post "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/thread_summary/regenerate", action: :regenerate_thread_summary, as: "#{context}_discussion_topic_thread_summary_regenerate"
         get "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/summaries", action: :find_summary, as: "#{context}_discussion_topic_summary"
         post "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/summaries", action: :find_or_create_summary, as: "#{context}_discussion_topic_create_summary"
         put "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/summaries/disable", action: :disable_summary, as: "#{context}_discussion_topic_disable_summary"

--- a/doc/discussion_thread_summarizer_api_embed.md
+++ b/doc/discussion_thread_summarizer_api_embed.md
@@ -4,6 +4,8 @@
 
 When the `discussion_thread_summarizer` course feature is enabled, the Discussion Topic REST `show`/`view` responses and GraphQL `Discussion.summary` field include an optional `summary` object (`text`, `status`, `generated_at`). When the flag is off, response shapes are unchanged.
 
+The dedicated `GET .../thread_summary` endpoint also includes a `regeneration` object (`available`, optional `retry_after_seconds`, optional `reason`) so clients can render regenerate cooldown state. `POST .../thread_summary/regenerate` enqueues manual regeneration when allowed; returns `429` with `retry_after_seconds` on cooldown deny or `quota_exhausted` when the daily budget is spent.
+
 ## Surfaces
 
 | Surface | Flag off | Flag on, cached | Flag on, generating | Flag on, not started |

--- a/spec/controllers/discussion_topics_api_controller_spec.rb
+++ b/spec/controllers/discussion_topics_api_controller_spec.rb
@@ -1467,6 +1467,93 @@ describe DiscussionTopicsApiController do
       expect(body).to be_present
       expect(body["status"]).to eq("generating")
     end
+
+    it "includes regeneration metadata on GET when preview allows" do
+      get "thread_summary",
+          params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+          format: "json"
+
+      expect(response.parsed_body["regeneration"]).to eq("available" => true)
+    end
+
+    it "includes cooldown retry_after_seconds on GET when preview denies" do
+      cooldown_key = ["discussion_thread_summarizer", "cooldown", @student.id, @topic.id].cache_key
+      allow(Canvas.redis).to receive(:get) { |key| key == cooldown_key ? "1" : nil }
+      allow(Canvas.redis).to receive(:ttl).with(cooldown_key).and_return(240)
+
+      get "thread_summary",
+          params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+          format: "json"
+
+      expect(response.parsed_body["regeneration"]).to eq(
+        "available" => false,
+        "reason" => "cooldown",
+        "retry_after_seconds" => 240
+      )
+    end
+  end
+
+  context "regenerate_thread_summary (Discussion Thread Summarizer)" do
+    before do
+      course_with_teacher(active_all: true)
+      student_in_course(active_all: true, course: @course)
+      @course.enable_feature!(:discussion_thread_summarizer)
+      @topic = @course.discussion_topics.create!(title: "discussion", user: @teacher)
+      @topic.discussion_entries.create!(user: @teacher, message: "hello")
+      user_session(@student)
+      allow(Canvas).to receive(:redis_enabled?).and_return(true)
+      allow(Canvas.redis).to receive(:get).and_return(nil)
+    end
+
+    it "enqueues regeneration when cooldown and quota allow" do
+      allow(Canvas.redis).to receive(:set).and_return(true)
+      allow(Canvas.redis).to receive(:incr).and_return(1)
+      allow(Canvas.redis).to receive(:expire)
+
+      expect do
+        post "regenerate_thread_summary",
+             params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+             format: "json"
+      end.to change { Delayed::Job.count }.by(1)
+
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq("status" => "generating", "enqueued" => true)
+    end
+
+    it "returns 429 with retry_after_seconds when cooldown denies" do
+      cooldown_key = ["discussion_thread_summarizer", "cooldown", @student.id, @topic.id].cache_key
+      allow(Canvas.redis).to receive(:set).with(cooldown_key, 1, nx: true, ex: 600).and_return(false)
+      allow(Canvas.redis).to receive(:ttl).with(cooldown_key).and_return(180)
+
+      expect do
+        post "regenerate_thread_summary",
+             params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+             format: "json"
+      end.not_to change { Delayed::Job.count }
+
+      expect(response).to have_http_status :too_many_requests
+      expect(response.parsed_body).to eq(
+        "error" => "cooldown",
+        "retry_after_seconds" => 180
+      )
+    end
+
+    it "returns 429 quota_exhausted when the daily budget is spent" do
+      allow(Canvas.redis).to receive(:set).and_return(true)
+      allow(Canvas.redis).to receive(:incr).and_return(101)
+      allow(Canvas.redis).to receive(:decr)
+      allow(Canvas.redis).to receive(:expire)
+
+      expect do
+        post "regenerate_thread_summary",
+             params: { topic_id: @topic.id, course_id: @course.id, user_id: @student.id },
+             format: "json"
+      end.not_to change { Delayed::Job.count }
+
+      expect(response).to have_http_status :too_many_requests
+      expect(response.parsed_body["error"]).to eq("quota_exhausted")
+      expect(response.parsed_body["message"]).to be_present
+    end
   end
 
   context "thread summary embed on show" do

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/ThreadSummaryBlock.tsx
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/ThreadSummaryBlock.tsx
@@ -19,18 +19,21 @@
 import React from 'react'
 import {useScope as createI18nScope} from '@canvas/i18n'
 import {Alert} from '@instructure/ui-alerts'
+import {Button} from '@instructure/ui-buttons'
 import {Flex} from '@instructure/ui-flex'
 import {Heading} from '@instructure/ui-heading'
 import {Spinner} from '@instructure/ui-spinner'
 import {Text} from '@instructure/ui-text'
 import {View} from '@instructure/ui-view'
+import {formatRegenerationCooldownLabel} from './formatRegenerationCooldown'
 import {formatThreadSummary} from './formatThreadSummary'
 import {useThreadSummary} from './useThreadSummary'
 
 const I18n = createI18nScope('discussion_topics_post')
 
 export const ThreadSummaryBlock = () => {
-  const {data, loading, error} = useThreadSummary()
+  const {data, loading, error, regeneration, quotaExhaustedMessage, regenerate, regenerating} =
+    useThreadSummary()
 
   if ((loading && !data) || !data || data.status === 'disabled') {
     return null
@@ -47,6 +50,54 @@ export const ThreadSummaryBlock = () => {
   }
 
   const summaryText = formatThreadSummary(data.summary)
+  const isGenerating = data.status === 'generating'
+  const isCooldown =
+    regeneration?.available === false && regeneration.reason === 'cooldown'
+  const cooldownSeconds = regeneration?.retry_after_seconds
+  const showRegenerateButton = !isGenerating
+
+  const handleRegenerateClick = (
+    event: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<Element>,
+  ) => {
+    if (isCooldown) {
+      event.preventDefault()
+      return
+    }
+    void regenerate()
+  }
+
+  const renderRegenerateButton = () => {
+    if (!showRegenerateButton) {
+      return null
+    }
+
+    return (
+      <Flex.Item>
+        <Flex direction="column" alignItems="end">
+          <Flex.Item>
+            <Button
+              color="secondary"
+              size="small"
+              data-testid="thread-summary-regenerate-button"
+              aria-disabled={isCooldown ? 'true' : undefined}
+              aria-label={I18n.t('Regenerate summary')}
+              onClick={handleRegenerateClick}
+              disabled={regenerating}
+            >
+              {I18n.t('Regenerate summary')}
+            </Button>
+          </Flex.Item>
+          {isCooldown && cooldownSeconds != null && (
+            <Flex.Item margin="x-small 0 0 0">
+              <Text size="small" data-testid="thread-summary-regenerate-cooldown">
+                {formatRegenerationCooldownLabel(cooldownSeconds)}
+              </Text>
+            </Flex.Item>
+          )}
+        </Flex>
+      </Flex.Item>
+    )
+  }
 
   const renderSummaryText = () => {
     if (!summaryText) {
@@ -124,11 +175,28 @@ export const ThreadSummaryBlock = () => {
       data-testid="thread-summary-block"
     >
       <Flex direction="column">
+        {quotaExhaustedMessage && (
+          <Flex.Item margin="0 0 small 0">
+            <Alert
+              variant="warning"
+              margin="0"
+              hasShadow={false}
+              data-testid="thread-summary-quota-exhausted"
+            >
+              {quotaExhaustedMessage}
+            </Alert>
+          </Flex.Item>
+        )}
         <Flex.Item margin="0 0 small 0">
-          <Heading level="h3">{I18n.t('Thread summary')}</Heading>
-          <Text size="small" color="secondary">
-            {I18n.t('AI-generated thread summary')}
-          </Text>
+          <Flex justifyItems="space-between" alignItems="start">
+            <Flex.Item shouldGrow shouldShrink>
+              <Heading level="h3">{I18n.t('Thread summary')}</Heading>
+              <Text size="small" color="secondary">
+                {I18n.t('AI-generated thread summary')}
+              </Text>
+            </Flex.Item>
+            {renderRegenerateButton()}
+          </Flex>
         </Flex.Item>
         {renderContent()}
       </Flex>

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/ThreadSummaryBlock.test.tsx
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/ThreadSummaryBlock.test.tsx
@@ -18,6 +18,7 @@
 
 import React from 'react'
 import {act, render, waitFor} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import fakeENV from '@canvas/test-utils/fakeENV'
 import {setupServer} from 'msw/node'
 import {http, HttpResponse} from 'msw'
@@ -43,6 +44,8 @@ const sampleSummary = {
 
 const threadSummaryPath =
   '/api/v1/courses/1234/discussion_topics/5678/thread_summary'
+
+const threadSummaryRegeneratePath = `${threadSummaryPath}/regenerate`
 
 const setup = () => render(<ThreadSummaryBlock />)
 
@@ -70,6 +73,12 @@ describe('ThreadSummaryBlock', () => {
 
   const mockThreadSummary = (body: ThreadSummaryData) => {
     server.use(http.get(threadSummaryPath, () => HttpResponse.json(body)))
+  }
+
+  const mockRegenerate = (
+    handler: () => ReturnType<typeof HttpResponse.json> | Response,
+  ) => {
+    server.use(http.post(threadSummaryRegeneratePath, handler))
   }
 
   it('does not render when the API returns disabled', async () => {
@@ -201,5 +210,124 @@ describe('ThreadSummaryBlock', () => {
 
     expect(await findByTestId('thread-summary-text')).toBeInTheDocument()
     expect(await findByTestId('thread-summary-rate-limited-stale')).toBeInTheDocument()
+  })
+
+  it('enqueues regeneration and shows generating state when regenerate succeeds', async () => {
+    let regenerateCount = 0
+
+    mockThreadSummary({
+      status: 'current',
+      enabled: true,
+      enqueued: false,
+      summary: sampleSummary,
+      record_id: 1,
+      regeneration: {available: true},
+    })
+
+    mockRegenerate(() => {
+      regenerateCount += 1
+      return HttpResponse.json({status: 'generating', enqueued: true})
+    })
+
+    server.use(
+      http.get(threadSummaryPath, () => {
+        if (regenerateCount > 0) {
+          return HttpResponse.json({
+            status: 'generating',
+            enabled: true,
+            enqueued: true,
+            summary: null,
+            record_id: 1,
+            regeneration: {available: false, reason: 'cooldown', retry_after_seconds: 600},
+          })
+        }
+        return HttpResponse.json({
+          status: 'current',
+          enabled: true,
+          enqueued: false,
+          summary: sampleSummary,
+          record_id: 1,
+          regeneration: {available: true},
+        })
+      }),
+    )
+
+    const user = userEvent.setup()
+    const {findByTestId, queryByTestId} = setup()
+
+    const button = await findByTestId('thread-summary-regenerate-button')
+    await user.click(button)
+
+    await waitFor(() => {
+      expect(regenerateCount).toBe(1)
+    })
+    expect(await findByTestId('thread-summary-generating')).toBeInTheDocument()
+    expect(queryByTestId('thread-summary-regenerate-button')).toBeNull()
+  })
+
+  it('shows cooldown feedback with aria-disabled and does not POST when in cooldown', async () => {
+    let regenerateCount = 0
+
+    mockThreadSummary({
+      status: 'current',
+      enabled: true,
+      enqueued: false,
+      summary: sampleSummary,
+      record_id: 1,
+      regeneration: {
+        available: false,
+        reason: 'cooldown',
+        retry_after_seconds: 240,
+      },
+    })
+
+    mockRegenerate(() => {
+      regenerateCount += 1
+      return HttpResponse.json({error: 'cooldown', retry_after_seconds: 240}, {status: 429})
+    })
+
+    const user = userEvent.setup()
+    const {findByTestId} = setup()
+
+    const button = await findByTestId('thread-summary-regenerate-button')
+    expect(button).toHaveAttribute('aria-disabled', 'true')
+    expect(button).not.toHaveAttribute('disabled')
+
+    button.focus()
+    expect(button).toHaveFocus()
+
+    await user.click(button)
+
+    expect(regenerateCount).toBe(0)
+    expect(await findByTestId('thread-summary-regenerate-cooldown')).toBeInTheDocument()
+  })
+
+  it('shows inline quota-exhausted message instead of a toast', async () => {
+    mockThreadSummary({
+      status: 'current',
+      enabled: true,
+      enqueued: false,
+      summary: sampleSummary,
+      record_id: 1,
+      regeneration: {available: true},
+    })
+
+    mockRegenerate(() =>
+      HttpResponse.json(
+        {
+          error: 'quota_exhausted',
+          message: 'Daily regeneration limit reached. Try again later.',
+        },
+        {status: 429},
+      ),
+    )
+
+    const user = userEvent.setup()
+    const {findByTestId, queryByTestId} = setup()
+
+    await user.click(await findByTestId('thread-summary-regenerate-button'))
+
+    expect(await findByTestId('thread-summary-quota-exhausted')).toBeInTheDocument()
+    expect(queryByTestId('thread-summary-generating')).toBeNull()
   })
 })

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/formatRegenerationCooldown.test.ts
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/formatRegenerationCooldown.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  formatRegenerationCooldownLabel,
+  minutesUntilAvailable,
+} from '../formatRegenerationCooldown'
+
+describe('minutesUntilAvailable', () => {
+  it('rounds up partial minutes', () => {
+    expect(minutesUntilAvailable(61)).toBe(2)
+    expect(minutesUntilAvailable(120)).toBe(2)
+    expect(minutesUntilAvailable(121)).toBe(3)
+  })
+
+  it('returns at least one minute for non-positive values', () => {
+    expect(minutesUntilAvailable(0)).toBe(1)
+    expect(minutesUntilAvailable(-5)).toBe(1)
+  })
+})
+
+describe('formatRegenerationCooldownLabel', () => {
+  const t = vi.fn((key, options) => {
+    if (typeof key === 'object' && options?.count === 1) {
+      return 'Available in 1 minute'
+    }
+    return `Available in ${options?.count} minutes`
+  })
+
+  it('formats singular minute', () => {
+    expect(formatRegenerationCooldownLabel(45, t)).toBe('Available in 1 minute')
+  })
+
+  it('formats plural minutes using rounded-up value', () => {
+    expect(formatRegenerationCooldownLabel(130, t)).toBe('Available in 3 minutes')
+  })
+})

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/buildThreadSummaryPaths.ts
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/buildThreadSummaryPaths.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare const ENV: {
+  context_type?: string
+  context_id?: string | number
+  discussion_topic_id?: string | number
+}
+
+function threadSummaryBasePath(): string {
+  const contextType = (ENV.context_type || 'Course').toLowerCase()
+  const contextId = ENV.context_id
+  const topicId = ENV.discussion_topic_id
+  return `/api/v1/${contextType}s/${contextId}/discussion_topics/${topicId}/thread_summary`
+}
+
+export function buildThreadSummaryPath(locale: string): string {
+  return `${threadSummaryBasePath()}?locale=${encodeURIComponent(locale)}`
+}
+
+export function buildThreadSummaryRegeneratePath(): string {
+  return `${threadSummaryBasePath()}/regenerate`
+}

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/formatRegenerationCooldown.ts
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/formatRegenerationCooldown.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {useScope as createI18nScope} from '@canvas/i18n'
+
+const I18n = createI18nScope('discussion_topics_post')
+
+type TranslateFn = typeof I18n.t
+
+/**
+ * Converts a cooldown-remaining value (seconds) into whole minutes for display.
+ * Rounds up so partial minutes never understate the wait.
+ */
+export function minutesUntilAvailable(retryAfterSeconds: number): number {
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds <= 0) {
+    return 1
+  }
+  return Math.max(1, Math.ceil(retryAfterSeconds / 60))
+}
+
+/**
+ * Formats the regenerate-button cooldown label ("Available in X minutes").
+ */
+export function formatRegenerationCooldownLabel(
+  retryAfterSeconds: number,
+  t: TranslateFn = I18n.t.bind(I18n),
+): string {
+  const minutes = minutesUntilAvailable(retryAfterSeconds)
+  return t(
+    {one: 'Available in 1 minute', other: 'Available in %{count} minutes'},
+    {count: minutes},
+  )
+}

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/useThreadSummary.ts
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/useThreadSummary.ts
@@ -32,8 +32,15 @@
  */
 
 import {useCallback, useEffect, useState} from 'react'
-import doFetchApi from '@canvas/do-fetch-api-effect'
+import doFetchApi, {FetchApiError} from '@canvas/do-fetch-api-effect'
+import {useScope as createI18nScope} from '@canvas/i18n'
 import type {ThreadSummaryPayload} from './formatThreadSummary'
+import {
+  buildThreadSummaryPath,
+  buildThreadSummaryRegeneratePath,
+} from './buildThreadSummaryPaths'
+
+const I18n = createI18nScope('discussion_topics_post')
 
 export type ThreadSummaryStatus =
   | 'current'
@@ -43,21 +50,33 @@ export type ThreadSummaryStatus =
   | 'rate_limited_empty'
   | 'disabled'
 
+export type ThreadSummaryRegenerationReason = 'cooldown' | 'quota_exhausted'
+
+export interface ThreadSummaryRegeneration {
+  available: boolean
+  retry_after_seconds?: number
+  reason?: ThreadSummaryRegenerationReason
+}
+
 export interface ThreadSummaryData {
   status: ThreadSummaryStatus
   enabled: boolean
   enqueued: boolean
   summary: ThreadSummaryPayload | null
   record_id: number | null
+  regeneration?: ThreadSummaryRegeneration | null
+}
+
+export interface ThreadSummaryRegenerateErrorBody {
+  error?: string
+  retry_after_seconds?: number
+  message?: string
 }
 
 export const POLL_GENERATING_MS = 5000
 export const POLL_STALE_MS = 30000
 
 declare const ENV: {
-  context_type?: string
-  context_id?: string | number
-  discussion_topic_id?: string | number
   LOCALE?: string
 }
 
@@ -74,11 +93,12 @@ export function pollIntervalForStatus(status: ThreadSummaryStatus | null | undef
   return null
 }
 
-function buildThreadSummaryPath(locale: string): string {
-  const contextType = (ENV.context_type || 'Course').toLowerCase()
-  const contextId = ENV.context_id
-  const topicId = ENV.discussion_topic_id
-  return `/api/v1/${contextType}s/${contextId}/discussion_topics/${topicId}/thread_summary?locale=${encodeURIComponent(locale)}`
+async function parseRegenerateErrorBody(response: Response): Promise<ThreadSummaryRegenerateErrorBody> {
+  try {
+    return (await response.json()) as ThreadSummaryRegenerateErrorBody
+  } catch {
+    return {}
+  }
 }
 
 export function useThreadSummary() {
@@ -86,6 +106,10 @@ export function useThreadSummary() {
   const [data, setData] = useState<ThreadSummaryData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
+  const [regeneration, setRegeneration] = useState<ThreadSummaryRegeneration | null>(null)
+  const [quotaExhaustedMessage, setQuotaExhaustedMessage] = useState<string | null>(null)
+  const [refreshToken, setRefreshToken] = useState(0)
+  const [regenerating, setRegenerating] = useState(false)
 
   const fetchSummary = useCallback(
     async (signal: AbortSignal) => {
@@ -120,6 +144,7 @@ export function useThreadSummary() {
           return
         }
         setData(result)
+        setRegeneration(result?.regeneration ?? null)
         setError(null)
         clearPoll()
         const intervalMs = pollIntervalForStatus(result?.status)
@@ -147,7 +172,60 @@ export function useThreadSummary() {
       controller.abort()
       clearPoll()
     }
-  }, [fetchSummary, locale])
+  }, [fetchSummary, locale, refreshToken])
 
-  return {data, loading, error}
+  const regenerate = useCallback(async () => {
+    if (regenerating || regeneration?.available === false) {
+      return
+    }
+
+    setRegenerating(true)
+    setQuotaExhaustedMessage(null)
+
+    try {
+      await doFetchApi({
+        path: buildThreadSummaryRegeneratePath(),
+        method: 'POST',
+      })
+      setRegeneration({available: true})
+      setData(prev =>
+        prev
+          ? {
+              ...prev,
+              status: 'generating',
+              enqueued: true,
+            }
+          : prev,
+      )
+      setRefreshToken(token => token + 1)
+    } catch (err) {
+      if (err instanceof FetchApiError && err.response.status === 429) {
+        const body = await parseRegenerateErrorBody(err.response)
+        if (body.error === 'cooldown' && body.retry_after_seconds != null) {
+          setRegeneration({
+            available: false,
+            reason: 'cooldown',
+            retry_after_seconds: body.retry_after_seconds,
+          })
+          return
+        }
+        if (body.error === 'quota_exhausted') {
+          setQuotaExhaustedMessage(
+            body.message ||
+              I18n.t('Daily regeneration limit reached. Try again later.'),
+          )
+          setRegeneration({
+            available: false,
+            reason: 'quota_exhausted',
+          })
+          return
+        }
+      }
+      setError(err instanceof Error ? err : new Error(String(err)))
+    } finally {
+      setRegenerating(false)
+    }
+  }, [regenerating, regeneration?.available])
+
+  return {data, loading, error, regeneration, quotaExhaustedMessage, regenerate, regenerating}
 }


### PR DESCRIPTION
## Summary

- **#23 (frontend):** Regenerate summary button in `ThreadSummaryBlock` with accessible cooldown feedback (`aria-disabled`, focusable), inline quota-exhaustion alert (no toast), pure `formatRegenerationCooldown` helper, and MSW/RTL tests.
- **#121 (backend):** `POST .../thread_summary/regenerate`, `SummarizationService#request_regenerate`, `RegenerationRateLimiter.cooldown_remaining_seconds`, and additive `regeneration` metadata on `GET .../thread_summary`.

## Paired-issue rationale

The regenerate route was assumed by #23 (FR-7) but absent on `master` after #18 (rate limiter) and #84 (GET render path). Rather than unwind the branch, both slices land together — mirroring the Cycle 23 **#24 + #26** paired precedent for clean issue→code traceability.

closes #23
closes #121

## Test plan

- [x] `yarn test ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/formatRegenerationCooldown.test.ts ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/ThreadSummaryBlock.test.tsx --run` — **14 passed**
- [x] `bin/rspec spec/controllers/discussion_topics_api_controller_spec.rb -e "thread_summary (Discussion Thread Summarizer)" -e "regenerate_thread_summary"` — **11 passed**
- [x] Diff is source + specs + release-note doc only (no `.vscode/`, no evidence files)


Made with [Cursor](https://cursor.com)