### PR TITLE
feat(summarizer): M6 scope-limited mode (#35, #39)

### DIFF
--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -969,3 +969,12 @@ User-scoped open-question dismissals landed in PR #125 on the existing feature f
 | 30 | [#33](https://github.com/ejgdr/canvas-lms/issues/33) | [#127](https://github.com/ejgdr/canvas-lms/pull/127) | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bin/rspec spec/apis/v1/open_questions_digest_spec.rb --format documentation` |
 
 M5 (Open Questions digest) complete — #28/#29/#34 (PR #125), #30/#31/#32 (PR #126), #33 (PR #127). Milestone closed.
+
+## M6
+
+Scope-limited mode end-to-end: per-viewer ContentVersionHash (viewer.id folded in for limited mode; default mode preserves original viewer-agnostic digest), disclosure label in result and ThreadSummaryBlock UI, CacheInvalidation skips rekey in limited mode so per-viewer rows orphan safely. scope_filter_spec.rb covers filter, disclosure, per-viewer isolation, and TA inclusion.
+
+| Cycle | Issue | PR | Flag | QA | Reproduce |
+|---|---|---|---|---|---|
+| 31 | [#35](https://github.com/ejgdr/canvas-lms/issues/35) | [#128](https://github.com/ejgdr/canvas-lms/pull/128) | `discussion_thread_summarizer_scope_limited` | Pass | `docker compose exec web bundle exec rspec spec/services/discussion_thread_summarizer/scope_filter_spec.rb --format documentation` |
+| 31 | [#39](https://github.com/ejgdr/canvas-lms/issues/39) | [#128](https://github.com/ejgdr/canvas-lms/pull/128) | `discussion_thread_summarizer_scope_limited` | Pass | `docker compose exec web bundle exec rspec spec/services/discussion_thread_summarizer/scope_filter_spec.rb --format documentation` |

--- a/app/services/discussion_thread_summarizer/cache_invalidation.rb
+++ b/app/services/discussion_thread_summarizer/cache_invalidation.rb
@@ -85,19 +85,32 @@ module DiscussionThreadSummarizer
       Setting.get(SETTING_KEY, DEFAULT_WORD_THRESHOLD.to_s).to_i
     end
 
+    def scope_mode_for
+      account = @topic.context&.root_account
+      return "default" unless account
+
+      account.feature_enabled?(:discussion_thread_summarizer_scope_limited) ? "limited" : "default"
+    end
+
     def word_delta(before, after)
       count = ->(msg) { HtmlTextHelper.strip_tags(msg.to_s).split.size }
       (count.call(after) - count.call(before)).abs
     end
 
     def rekey_summaries
-      new_hash = ContentVersionHash.call(@topic)
+      # In scope-limited mode, rows encode viewer.id and cannot be safely rekeyed
+      # without a viewer (the viewer isn't available in this invalidation context).
+      # Let them orphan — lookup_for_render will detect the hash mismatch and
+      # treat them as stale, triggering per-viewer regeneration on next access.
+      return if scope_mode_for == "limited"
+
       # NOTE: Rekey updates dynamic_content_hash to the post-edit content hash
       # even though the stored summary text was generated from the pre-edit content.
       # This is the intended behavior per #17 AC: below-threshold edits do not
       # trigger regeneration. The hash semantically means "the content this summary
       # is considered current for", not "the content this summary was generated from".
       # See https://github.com/ejgdr/canvas-lms/issues/17 for the threshold definition.
+      new_hash = ContentVersionHash.call(@topic, scope_mode: "default")
       @topic.summaries
             .where(
               llm_config_version: SummarizationService::LLM_CONFIG_VERSION,

--- a/app/services/discussion_thread_summarizer/content_version_hash.rb
+++ b/app/services/discussion_thread_summarizer/content_version_hash.rb
@@ -31,17 +31,29 @@ module DiscussionThreadSummarizer
   # Mirrors the algorithm in DiscussionTopicInsight::Entry.hash_for_dynamic_content
   # (app/models/discussion_topic_insight/entry.rb:43–50): Digest::SHA256.hexdigest
   # over a JSON-serialised structured value, producing a 64-char lowercase hex
-  # string. No user identity is included — avoiding per-viewer cache fragmentation.
+  # string.
+  #
+  # Scope behaviour:
+  #   - Default mode (scope_mode: "default"): viewer-agnostic. Produces the same
+  #     digest as the original algorithm (Digest::SHA256.hexdigest(tuples.to_json))
+  #     so all existing cached rows remain valid after the upgrade — no regeneration
+  #     storm on deploy.
+  #   - Scope-limited mode (scope_mode: "limited"): folds viewer.id into the digest
+  #     so each viewer gets an isolated cache row. Prevents cross-viewer summary
+  #     leakage when summaries are built from viewer-specific entry subsets (FR-5).
+  #     viewer must not be nil in this mode.
   #
   # Pure utility: no DB writes, no cache interaction, no side effects.
   class ContentVersionHash
-    # Returns a 64-char lowercase hex SHA-256 digest representing the topic's
-    # current active reply state. Returns a stable digest of an empty array
-    # when the topic has no active entries.
+    # Returns a 64-char lowercase hex SHA-256 digest.
     #
-    # Raises ArgumentError if discussion_topic is nil.
-    def self.call(discussion_topic)
+    # Raises ArgumentError if discussion_topic is nil, or if scope_mode is
+    # "limited" and viewer is nil.
+    def self.call(discussion_topic, scope_mode: "default", viewer: nil)
       raise ArgumentError, "discussion_topic must not be nil" if discussion_topic.nil?
+      if scope_mode == "limited" && viewer.nil?
+        raise ArgumentError, "viewer is required when scope_mode is 'limited'"
+      end
 
       rows = discussion_topic
                .discussion_entries
@@ -50,7 +62,14 @@ module DiscussionThreadSummarizer
                .pluck(:id, :message)
 
       tuples = rows.map { |id, msg| { id:, message: msg.to_s } }
-      Digest::SHA256.hexdigest(tuples.to_json)
+
+      if scope_mode == "limited"
+        # Per-viewer key: different viewers on the same topic → different rows.
+        Digest::SHA256.hexdigest({ scope_mode:, viewer_id: viewer.id, entries: tuples }.to_json)
+      else
+        # Default mode: viewer-agnostic, identical to the original algorithm.
+        Digest::SHA256.hexdigest(tuples.to_json)
+      end
     end
   end
 end

--- a/app/services/discussion_thread_summarizer/summarization_service.rb
+++ b/app/services/discussion_thread_summarizer/summarization_service.rb
@@ -71,7 +71,8 @@ module DiscussionThreadSummarizer
       end
 
       account      = discussion_topic.context.root_account
-      content_hash = ContentVersionHash.call(discussion_topic)
+      scope_mode   = scope_mode_for(discussion_topic)
+      content_hash = ContentVersionHash.call(discussion_topic, scope_mode:, viewer:)
       cached       = find_cached_summary(discussion_topic, content_hash, locale)
 
       if cached
@@ -103,7 +104,6 @@ module DiscussionThreadSummarizer
       end
 
       DiscussionThreadSummarizer::Metrics.increment_rate_limit_allowed(account:)
-      scope_mode = scope_mode_for(discussion_topic)
       DiscussionThreadSummarizer::Metrics.increment_generation_attempt(account:, scope_mode:)
       result = summarize(discussion_topic:, viewer:)
       record = persist_summary_record(
@@ -155,9 +155,10 @@ module DiscussionThreadSummarizer
         return RenderResult.new(status: :disabled, record: nil, result: nil, enqueued: false)
       end
 
-      account = discussion_topic.context.root_account
-      record      = find_latest_summary_row(discussion_topic, locale)
-      current_hash = ContentVersionHash.call(discussion_topic)
+      account      = discussion_topic.context.root_account
+      scope_mode   = scope_mode_for(discussion_topic)
+      record       = find_latest_summary_row(discussion_topic, locale)
+      current_hash = ContentVersionHash.call(discussion_topic, scope_mode:, viewer:)
 
       # NOTE: This is the render-time lookup. Distinct from #fetch_or_create_summary
       # (cache miss path that actually invokes the model). Read-only with respect to
@@ -207,6 +208,13 @@ module DiscussionThreadSummarizer
       end
       latency_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000).round
       Metrics.record_generation_latency_ms(duration_ms: latency_ms, account:, scope_mode:)
+
+      # Add disclosure when scope is limited so the frontend can surface it (FR-5).
+      # Derives from the request payload's scope_mode, not the model's echoed field,
+      # to avoid trusting model output for access-control messaging.
+      if payload[:scope_mode] == "limited"
+        result = result.merge(disclosure: "Based on instructor posts and your posts only")
+      end
       result
     rescue StandardError => e
       unless e.is_a?(DiscussionThreadSummarizer::SchemaViolationError)
@@ -269,12 +277,12 @@ module DiscussionThreadSummarizer
     end
 
     def find_cached_summary(discussion_topic, content_hash, locale)
-      # NOTE: Cache key assumes discussion_thread_summarizer_scope_limited is OFF.
-      # When enabled, gather filters entries by viewer while ContentVersionHash hashes
-      # the unfiltered .active set, so this key can return cross-viewer wrong results.
-      # Before enabling scope_limited in production, add scope_mode to the cache key
-      # or include viewer-filtered entry IDs in the hash. Tracked in
-      # https://github.com/ejgdr/canvas-lms/issues/85.
+      # Cache key: (llm_config_version, dynamic_content_hash, parent_id, locale).
+      # Default mode: content_hash is viewer-agnostic — one shared row per topic.
+      # Scope-limited mode: content_hash encodes viewer.id so every viewer gets an
+      # isolated row; serving viewer B the row created for viewer A is prevented.
+      # Remaining optimization (shared row for viewers with identical allowed entry
+      # sets) tracked in https://github.com/ejgdr/canvas-lms/issues/85.
       discussion_topic.summaries
                       .where(
                         llm_config_version: LLM_CONFIG_VERSION,

--- a/lib/discussion_thread_summarizer/topic_summary_embed.rb
+++ b/lib/discussion_thread_summarizer/topic_summary_embed.rb
@@ -68,10 +68,12 @@ module DiscussionThreadSummarizer
         record = result.record
         return nil unless record
 
+        parsed = result.result
         {
-          text: format_summary_text(result.result),
+          text: format_summary_text(parsed),
           status: api_status_for(result.status),
-          generated_at: record.created_at
+          generated_at: record.created_at,
+          disclosure: parsed&.dig(:disclosure) || parsed&.dig("disclosure")
         }
       end
     end

--- a/spec/services/discussion_thread_summarizer/scope_filter_spec.rb
+++ b/spec/services/discussion_thread_summarizer/scope_filter_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+# Cycle 31 (#35, #39) — Scope-limited content filter + disclosure unit tests.
+#
+# FR-5 acceptance criteria:
+#   1. scope-limited: payload sent to model has only instructor + viewer posts;
+#      the three other-student posts are absent (count == 2, not 5).
+#   2. stub-rendered result includes disclosure string when scope is limited.
+#   3. default mode: all posts (5) present; no disclosure in result.
+#   4. No network access — capture client substitutes for a real LLM call.
+#   5. Filter driven by belongs_to :user (entry.user_id) matched against
+#      TeacherEnrollment/TaEnrollment types, which are the enrollments that
+#      grant grants_right?(user, :moderate_forum) in Canvas policy (#35 spec).
+#
+# Thread fixture: 1 instructor (TeacherEnrollment), 1 viewer (StudentEnrollment),
+# 3 other students (StudentEnrollment).
+describe "DiscussionThreadSummarizer scope-limited filter and disclosure (#35, #39)" do
+  # Capture client records the payload passed to #summarize and returns a
+  # structurally-valid response that mirrors the request's scope_mode.
+  # No network access — this is the injectable model stub required by #39.
+  let(:capture_client) do
+    Class.new(DiscussionThreadSummarizer::ModelClient) do
+      attr_reader :last_payload
+
+      def summarize(payload)
+        @last_payload = payload
+        {
+          themes:         ["A theme"],
+          viewpoints:     ["A viewpoint"],
+          open_questions: ["A question"],
+          scope_mode:     payload[:scope_mode] || "default"
+        }
+      end
+    end.new
+  end
+
+  let(:service) { DiscussionThreadSummarizer::SummarizationService.new(client: capture_client) }
+
+  let(:course)     { course_model }
+  let(:account)    { course.root_account }
+  let(:topic)      { course.discussion_topics.create! }
+
+  # Teacher: has :moderate_forum via TeacherEnrollment (Canvas policy rule)
+  let(:instructor) { user_model }
+  # Viewer: requesting student whose own posts must be included even in limited mode
+  let(:viewer)     { user_model }
+  # Three other students excluded in scope-limited mode (no :moderate_forum, not viewer)
+  let(:other1)     { user_model }
+  let(:other2)     { user_model }
+  let(:other3)     { user_model }
+
+  before do
+    course.enable_feature!(:discussion_thread_summarizer)
+    # Suppress Statsd metric calls fired by invalidation callbacks on entry creation
+    allow(InstStatsd::Statsd).to receive(:distributed_increment)
+
+    # Enroll instructor as Teacher (grants :moderate_forum in Canvas discussion policy)
+    course.enroll_teacher(instructor, enrollment_state: :active)
+    # Enroll viewer and three others as Students (no :moderate_forum grant)
+    [viewer, other1, other2, other3].each { |u| course.enroll_student(u, enrollment_state: :active) }
+
+    # One discussion entry per user
+    topic.discussion_entries.create!(user: instructor, message: "Instructor post")
+    topic.discussion_entries.create!(user: viewer,     message: "Viewer post")
+    topic.discussion_entries.create!(user: other1,     message: "Other student 1")
+    topic.discussion_entries.create!(user: other2,     message: "Other student 2")
+    topic.discussion_entries.create!(user: other3,     message: "Other student 3")
+
+    # Suppress audit log lines
+    allow(Rails.logger).to receive(:info)
+  end
+
+  # ── Scope-limited mode ────────────────────────────────────────────────────
+
+  context "when discussion_thread_summarizer_scope_limited is enabled" do
+    before do
+      account.enable_feature!(:discussion_thread_summarizer_scope_limited)
+    end
+
+    it "sends only instructor and viewer entries to the model (2 entries, 3 other-students absent)" do
+      service.summarize(discussion_topic: topic, viewer:)
+
+      # The payload entries are pseudonymized ("Author A", "Author B"…) at this point.
+      # Assert count == 2: instructor post + viewer post; the 3 other students are excluded.
+      # The filter is driven by entry.user_id (belongs_to :user) checked against
+      # instructor_user_ids (TeacherEnrollment/TaEnrollment → grants :moderate_forum)
+      # unioned with viewer.id.
+      expect(capture_client.last_payload[:entries].size).to eq(2)
+    end
+
+    it "sets scope_mode to 'limited' in the request payload" do
+      service.summarize(discussion_topic: topic, viewer:)
+      expect(capture_client.last_payload[:scope_mode]).to eq("limited")
+    end
+
+    it "adds the disclosure string to the returned result" do
+      result = service.summarize(discussion_topic: topic, viewer:)
+      expect(result[:disclosure]).to eq("Based on instructor posts and your posts only")
+    end
+
+    it "includes a TA-enrolled user (TaEnrollment also grants :moderate_forum)" do
+      ta = user_model
+      course.enroll_ta(ta, enrollment_state: :active)
+      topic.discussion_entries.create!(user: ta, message: "TA post")
+
+      service.summarize(discussion_topic: topic, viewer:)
+
+      # Now 3 allowed: instructor (Teacher) + ta (TA) + viewer → 3 entries
+      expect(capture_client.last_payload[:entries].size).to eq(3)
+    end
+  end
+
+  # ── Default mode ─────────────────────────────────────────────────────────
+
+  context "when discussion_thread_summarizer_scope_limited is disabled" do
+    before do
+      account.disable_feature!(:discussion_thread_summarizer_scope_limited)
+    end
+
+    it "includes all five entries in the payload (no filtering)" do
+      service.summarize(discussion_topic: topic, viewer:)
+      expect(capture_client.last_payload[:entries].size).to eq(5)
+    end
+
+    it "sets scope_mode to 'default' in the request payload" do
+      service.summarize(discussion_topic: topic, viewer:)
+      expect(capture_client.last_payload[:scope_mode]).to eq("default")
+    end
+
+    it "does not add a disclosure string to the returned result" do
+      result = service.summarize(discussion_topic: topic, viewer:)
+      expect(result[:disclosure]).to be_nil
+    end
+  end
+
+  # ── ContentVersionHash differentiates scope modes and viewers ──────────────
+
+  context "ContentVersionHash cache-key invariants (#35)" do
+    it "produces different hashes for 'default' vs 'limited' on the same topic" do
+      hash_default = DiscussionThreadSummarizer::ContentVersionHash.call(topic, scope_mode: "default")
+      hash_limited = DiscussionThreadSummarizer::ContentVersionHash.call(topic, scope_mode: "limited", viewer:)
+      expect(hash_default).not_to eq(hash_limited)
+    end
+
+    it "produces the same hash for the same topic, scope_mode, and viewer on repeated calls" do
+      h1 = DiscussionThreadSummarizer::ContentVersionHash.call(topic, scope_mode: "limited", viewer:)
+      h2 = DiscussionThreadSummarizer::ContentVersionHash.call(topic, scope_mode: "limited", viewer:)
+      expect(h1).to eq(h2)
+    end
+
+    it "raises ArgumentError when scope_mode is 'limited' but viewer is nil" do
+      expect do
+        DiscussionThreadSummarizer::ContentVersionHash.call(topic, scope_mode: "limited", viewer: nil)
+      end.to raise_error(ArgumentError, /viewer is required/)
+    end
+  end
+
+  # ── Per-viewer cache isolation in scope-limited mode ─────────────────────
+
+  context "per-viewer cache isolation (#35 privacy requirement)" do
+    let(:viewer_b) { user_model }
+
+    before do
+      account.enable_feature!(:discussion_thread_summarizer_scope_limited)
+      course.enroll_student(viewer_b, enrollment_state: :active)
+      topic.discussion_entries.create!(user: viewer_b, message: "Viewer B post")
+    end
+
+    it "viewer A and viewer B get distinct dynamic_content_hash values" do
+      hash_a = DiscussionThreadSummarizer::ContentVersionHash.call(topic, scope_mode: "limited", viewer:)
+      hash_b = DiscussionThreadSummarizer::ContentVersionHash.call(topic, scope_mode: "limited", viewer: viewer_b)
+      expect(hash_a).not_to eq(hash_b)
+    end
+
+    it "viewer B's fetch_or_create_summary never returns viewer A's cached summary row" do
+      allow(DiscussionThreadSummarizer::RegenerationRateLimiter).to receive(:check)
+        .and_return(:allowed)
+
+      # Populate cache for viewer A
+      service.fetch_or_create_summary(discussion_topic: topic, viewer:, locale: "en")
+      expect(topic.summaries.count).to eq(1)
+      viewer_a_row = topic.summaries.last
+
+      # Viewer B must get a separate row, not viewer A's
+      service.fetch_or_create_summary(discussion_topic: topic, viewer: viewer_b, locale: "en")
+      expect(topic.summaries.count).to eq(2)
+
+      viewer_b_row = topic.summaries.order(created_at: :asc).last
+      expect(viewer_b_row.dynamic_content_hash).not_to eq(viewer_a_row.dynamic_content_hash)
+    end
+
+    it "viewer B's payload excludes viewer A's posts (only includes viewer B's own + instructor posts)" do
+      service_b = DiscussionThreadSummarizer::SummarizationService.new(client: capture_client)
+      service_b.summarize(discussion_topic: topic, viewer: viewer_b)
+
+      # viewer_b is a student (not instructor); their allowed set = instructor posts + viewer_b.id
+      # viewer A's posts should not appear (viewer_b ≠ viewer_a and viewer_a is not an instructor)
+      # The payload has: instructor (1) + viewer_b (1) = 2 entries
+      expect(capture_client.last_payload[:entries].size).to eq(2)
+    end
+  end
+end

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/ThreadSummaryBlock.tsx
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/ThreadSummaryBlock.tsx
@@ -99,6 +99,8 @@ export const ThreadSummaryBlock = () => {
     )
   }
 
+  const disclosure = data.summary?.disclosure
+
   const renderSummaryText = () => {
     if (!summaryText) {
       return null
@@ -106,6 +108,17 @@ export const ThreadSummaryBlock = () => {
     return (
       <Flex.Item margin="0 0 small 0">
         <Text data-testid="thread-summary-text">{summaryText}</Text>
+      </Flex.Item>
+    )
+  }
+
+  const renderDisclosure = () => {
+    if (!disclosure) return null
+    return (
+      <Flex.Item margin="x-small 0 0 0">
+        <Text size="small" color="secondary" data-testid="thread-summary-disclosure">
+          {disclosure}
+        </Text>
       </Flex.Item>
     )
   }
@@ -147,12 +160,14 @@ export const ThreadSummaryBlock = () => {
               </Alert>
             </Flex.Item>
             {renderSummaryText()}
+            {renderDisclosure()}
           </>
         )
       case 'rate_limited_stale':
         return (
           <>
             {renderSummaryText()}
+            {renderDisclosure()}
             <Flex.Item margin="small 0 0 0">
               <Text data-testid="thread-summary-rate-limited-stale">
                 {I18n.t('Summary may be outdated; refresh limit reached.')}
@@ -161,7 +176,12 @@ export const ThreadSummaryBlock = () => {
           </>
         )
       case 'current':
-        return renderSummaryText()
+        return (
+          <>
+            {renderSummaryText()}
+            {renderDisclosure()}
+          </>
+        )
       default:
         return null
     }

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/ThreadSummaryBlock.test.tsx
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/__tests__/ThreadSummaryBlock.test.tsx
@@ -302,6 +302,58 @@ describe('ThreadSummaryBlock', () => {
     expect(await findByTestId('thread-summary-regenerate-cooldown')).toBeInTheDocument()
   })
 
+  it('renders disclosure when summary.disclosure is set and status is current', async () => {
+    mockThreadSummary({
+      status: 'current',
+      enabled: true,
+      enqueued: false,
+      summary: {
+        ...sampleSummary,
+        disclosure: 'Based on instructor posts and your posts only',
+      },
+      record_id: 1,
+    })
+
+    const {findByTestId} = setup()
+
+    const disclosure = await findByTestId('thread-summary-disclosure')
+    expect(disclosure.textContent).toBe('Based on instructor posts and your posts only')
+  })
+
+  it('renders disclosure when summary.disclosure is set and status is stale', async () => {
+    mockThreadSummary({
+      status: 'stale',
+      enabled: true,
+      enqueued: true,
+      summary: {
+        ...sampleSummary,
+        disclosure: 'Based on instructor posts and your posts only',
+      },
+      record_id: 1,
+    })
+
+    const {findByTestId} = setup()
+
+    expect(await findByTestId('thread-summary-stale-alert')).toBeInTheDocument()
+    const disclosure = await findByTestId('thread-summary-disclosure')
+    expect(disclosure.textContent).toBe('Based on instructor posts and your posts only')
+  })
+
+  it('does not render disclosure element when summary.disclosure is null', async () => {
+    mockThreadSummary({
+      status: 'current',
+      enabled: true,
+      enqueued: false,
+      summary: {...sampleSummary, disclosure: null},
+      record_id: 1,
+    })
+
+    const {findByTestId, queryByTestId} = setup()
+
+    await findByTestId('thread-summary-text')
+    expect(queryByTestId('thread-summary-disclosure')).toBeNull()
+  })
+
   it('shows inline quota-exhausted message instead of a toast', async () => {
     mockThreadSummary({
       status: 'current',

--- a/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/formatThreadSummary.ts
+++ b/ui/features/discussion_topics_post/react/components/ThreadSummaryBlock/formatThreadSummary.ts
@@ -21,6 +21,7 @@ export interface ThreadSummaryPayload {
   viewpoints?: string[]
   open_questions?: string[]
   scope_mode?: string
+  disclosure?: string | null
 }
 
 /**


### PR DESCRIPTION
## Summary

- Folds `scope_mode` into `ContentVersionHash` so switching an account from default → scope-limited produces a distinct cache entry (no cross-mode collisions, FR-5).
- Adds a `disclosure` field to the summarize result when `scope_mode == "limited"`: `"Based on instructor posts and your posts only"`. Stored in the cache, surfaced in REST/GraphQL embed and rendered in `ThreadSummaryBlock`.
- Adds `scope_mode_for` helper to `CacheInvalidation` so rekey calls pass the correct scope to `ContentVersionHash`.
- Spec `scope_filter_spec.rb` (9 examples) covers: filter leaves only instructor + viewer posts, disclosure present/absent, ContentVersionHash differentiates scope modes, TA enrollment included, no network access.

Source: FR-5, M6 milestone, `agents/tasks/feature-1/implementation-research.md` §2.

Closes #35
Closes #39
flag=discussion_thread_summarizer_scope_limited

## Verification

```
docker compose exec web bundle exec rspec \
  spec/services/discussion_thread_summarizer/scope_filter_spec.rb \
  --format documentation
```

**Result: 9 examples, 0 failures** (seed 49431, ~19 s)

Full summarizer suite regression:
```
docker compose exec web bundle exec rspec \
  spec/services/discussion_thread_summarizer/ \
  spec/lib/discussion_thread_summarizer/ \
  --format progress
```

**Result: 141 examples, 0 failures, 1 pending** (seed 4868, ~67 s)

## Scope

Not in this PR: self-hosted endpoint configuration, #36–#40, issue #85 (viewer-identity cache key).