### PR TITLE
feat(summarizer): M7 report backend #41 + #44 + #45

### DIFF
--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -984,3 +984,13 @@ Scope-limited mode end-to-end: per-viewer ContentVersionHash (viewer.id folded i
 | 33 | [#38](https://github.com/ejgdr/canvas-lms/issues/38) | [#130](https://github.com/ejgdr/canvas-lms/pull/130) | none (docs-only) | Skip — justified | n/a |
 
 M6 (Privacy controls) complete — #35/#39 (Cycle 31), #36/#37 (Cycle 32), #40/#38 (this cycle). Milestone closed.
+
+## M7
+
+Report storage against a specific summary version. `DiscussionTopicSummaryReport` (`belongs_to :discussion_topic_summary`) stores `reason`, `comment` (max 500 chars), `reporter_role` (derived from `grants_right?`), and `user_id` (never serialized). Route mirrors `regenerate`. Metric `discussion_thread_summarizer.report_submitted` tagged `reason` + `reporter_role` — no PII.
+
+| Cycle | Issue | PR | Flag | QA | Reproduce |
+|---|---|---|---|---|---|
+| 34 | [#41](https://github.com/ejgdr/canvas-lms/issues/41) | #PR | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bundle exec rspec spec/models/discussion_topic_summary_report_spec.rb --format documentation` |
+| 34 | [#44](https://github.com/ejgdr/canvas-lms/issues/44) | #PR | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bundle exec rspec spec/models/discussion_topic_summary_report_spec.rb --format documentation` |
+| 34 | [#45](https://github.com/ejgdr/canvas-lms/issues/45) | #PR | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bundle exec rspec spec/lib/discussion_thread_summarizer/metrics_spec.rb --format documentation` |

--- a/agents/tasks/feature-1/implementation-evidence.md
+++ b/agents/tasks/feature-1/implementation-evidence.md
@@ -991,6 +991,6 @@ Report storage against a specific summary version. `DiscussionTopicSummaryReport
 
 | Cycle | Issue | PR | Flag | QA | Reproduce |
 |---|---|---|---|---|---|
-| 34 | [#41](https://github.com/ejgdr/canvas-lms/issues/41) | #PR | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bundle exec rspec spec/models/discussion_topic_summary_report_spec.rb --format documentation` |
-| 34 | [#44](https://github.com/ejgdr/canvas-lms/issues/44) | #PR | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bundle exec rspec spec/models/discussion_topic_summary_report_spec.rb --format documentation` |
-| 34 | [#45](https://github.com/ejgdr/canvas-lms/issues/45) | #PR | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bundle exec rspec spec/lib/discussion_thread_summarizer/metrics_spec.rb --format documentation` |
+| 34 | [#41](https://github.com/ejgdr/canvas-lms/issues/41) | [#131](https://github.com/ejgdr/canvas-lms/pull/131) | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bundle exec rspec spec/models/discussion_topic_summary_report_spec.rb --format documentation` |
+| 34 | [#44](https://github.com/ejgdr/canvas-lms/issues/44) | [#131](https://github.com/ejgdr/canvas-lms/pull/131) | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bundle exec rspec spec/models/discussion_topic_summary_report_spec.rb --format documentation` |
+| 34 | [#45](https://github.com/ejgdr/canvas-lms/issues/45) | [#131](https://github.com/ejgdr/canvas-lms/pull/131) | `discussion_thread_summarizer` | Pass | `docker compose run --rm web bundle exec rspec spec/lib/discussion_thread_summarizer/metrics_spec.rb --format documentation` |

--- a/app/controllers/discussion_topics_api_controller.rb
+++ b/app/controllers/discussion_topics_api_controller.rb
@@ -255,6 +255,52 @@ class DiscussionTopicsApiController < ApplicationController
     end
   end
 
+  # @API Report thread summary (Discussion Thread Summarizer)
+  #
+  # Submits an inaccuracy or quality report against the current thread summary.
+  # Any viewer who can see the summary may report it.
+  # Does not invalidate the cache or trigger regeneration.
+  #
+  # @argument reason [Required, String, "inaccurate"|"missed_viewpoint"|"harmful_content"|"other"]
+  #   Category of the report.
+  #
+  # @argument comment [String]
+  #   Optional free-text elaboration (max 500 characters).
+  #
+  # @example_request
+  #
+  #     curl https://<canvas>/api/v1/courses/<course_id>/discussion_topics/<topic_id>/thread_summary/report \
+  #         -X POST \
+  #         -H 'Authorization: Bearer <token>' \
+  #         -d 'reason=inaccurate&comment=Details+here'
+  def report_thread_summary
+    raise ActiveRecord::RecordNotFound unless @context.is_a?(Course) && @context.feature_enabled?(:discussion_thread_summarizer)
+
+    summary = DiscussionTopicSummary
+              .where(discussion_topic: @topic, parent_id: nil, locale: I18n.locale.to_s)
+              .order(created_at: :desc)
+              .first
+
+    return render(json: { error: t("No summary found.") }, status: :not_found) unless summary
+
+    report = summary.reports.build(
+      user: @current_user,
+      reason: params[:reason],
+      comment: params[:comment].presence,
+      reporter_role: reporter_role_for_current_user
+    )
+
+    if report.save
+      DiscussionThreadSummarizer::Metrics.increment_report_submitted(
+        reason: report.reason,
+        reporter_role: report.reporter_role
+      )
+      render(json: report_thread_summary_json(report), status: :created)
+    else
+      render(json: { errors: report.errors.full_messages }, status: :unprocessable_entity)
+    end
+  end
+
   # @API Find or Create Summary
   #
   # Generates a summary for a discussion topic. Returns the summary text and usage information.
@@ -1529,6 +1575,26 @@ class DiscussionTopicsApiController < ApplicationController
       }
     when :quota_denied
       { available: false, reason: "quota_exhausted" }
+    end
+  end
+
+  def report_thread_summary_json(report)
+    {
+      id: report.id,
+      reason: report.reason,
+      comment: report.comment,
+      reporter_role: report.reporter_role,
+      created_at: report.created_at
+    }
+  end
+
+  def reporter_role_for_current_user
+    if @context.grants_right?(@current_user, session, :read_as_admin)
+      "admin"
+    elsif @context.grants_right?(@current_user, session, :moderate_forum)
+      "teacher"
+    else
+      "student"
     end
   end
 

--- a/app/controllers/discussion_topics_api_controller.rb
+++ b/app/controllers/discussion_topics_api_controller.rb
@@ -276,8 +276,8 @@ class DiscussionTopicsApiController < ApplicationController
   def report_thread_summary
     raise ActiveRecord::RecordNotFound unless @context.is_a?(Course) && @context.feature_enabled?(:discussion_thread_summarizer)
 
-    account     = @context.root_account
-    scope_mode  = account.feature_enabled?(:discussion_thread_summarizer_scope_limited) ? "limited" : "default"
+    account      = @context.root_account
+    scope_mode   = discussion_thread_summarizer_scope_mode(@context)
     content_hash = DiscussionThreadSummarizer::ContentVersionHash.call(@topic, scope_mode:, viewer: @current_user)
     locale       = I18n.locale.to_s
 

--- a/app/controllers/discussion_topics_api_controller.rb
+++ b/app/controllers/discussion_topics_api_controller.rb
@@ -276,10 +276,21 @@ class DiscussionTopicsApiController < ApplicationController
   def report_thread_summary
     raise ActiveRecord::RecordNotFound unless @context.is_a?(Course) && @context.feature_enabled?(:discussion_thread_summarizer)
 
-    summary = DiscussionTopicSummary
-              .where(discussion_topic: @topic, parent_id: nil, locale: I18n.locale.to_s)
-              .order(created_at: :desc)
-              .first
+    account     = @context.root_account
+    scope_mode  = account.feature_enabled?(:discussion_thread_summarizer_scope_limited) ? "limited" : "default"
+    content_hash = DiscussionThreadSummarizer::ContentVersionHash.call(@topic, scope_mode:, viewer: @current_user)
+    locale       = I18n.locale.to_s
+
+    # Find the exact summary version this viewer was shown (M6: per-viewer hash in limited mode).
+    summary = @topic.summaries
+                    .where(
+                      llm_config_version: DiscussionThreadSummarizer::SummarizationService::LLM_CONFIG_VERSION,
+                      dynamic_content_hash: content_hash,
+                      parent_id: nil,
+                      locale:
+                    )
+                    .order(created_at: :desc)
+                    .first
 
     return render(json: { error: t("No summary found.") }, status: :not_found) unless summary
 
@@ -293,7 +304,8 @@ class DiscussionTopicsApiController < ApplicationController
     if report.save
       DiscussionThreadSummarizer::Metrics.increment_report_submitted(
         reason: report.reason,
-        reporter_role: report.reporter_role
+        reporter_role: report.reporter_role,
+        account:
       )
       render(json: report_thread_summary_json(report), status: :created)
     else
@@ -1589,7 +1601,10 @@ class DiscussionTopicsApiController < ApplicationController
   end
 
   def reporter_role_for_current_user
-    if @context.grants_right?(@current_user, session, :read_as_admin)
+    # Check read_as_admin at account scope, not course scope.
+    # Course teachers hold :read_as_admin on the course itself; account admins hold
+    # it on the account. Checking @context.account isolates account-level admins.
+    if @context.account.grants_right?(@current_user, session, :read_as_admin)
       "admin"
     elsif @context.grants_right?(@current_user, session, :moderate_forum)
       "teacher"

--- a/app/models/discussion_topic_summary_report.rb
+++ b/app/models/discussion_topic_summary_report.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (C) 2024 - present Instructure, Inc.
+# Copyright (C) 2026 - present Instructure, Inc.
 #
 # This file is part of Canvas.
 #
@@ -16,22 +16,17 @@
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
-class DiscussionTopicSummary < ApplicationRecord
-  belongs_to :root_account, class_name: "Account"
+# Append-only report of an inaccuracy or quality issue against a specific
+# DiscussionTopicSummary version. user_id is stored for abuse-prevention purposes
+# and must never be serialized in API responses or admin output.
+class DiscussionTopicSummaryReport < ApplicationRecord
+  belongs_to :discussion_topic_summary
   belongs_to :user
-  belongs_to :discussion_topic, inverse_of: :summaries
-  belongs_to :parent, class_name: "DiscussionTopicSummary", optional: true
 
-  has_many :feedback, class_name: "DiscussionTopicSummary::Feedback"
-  has_many :reports, class_name: "DiscussionTopicSummaryReport"
+  REASONS = %w[inaccurate missed_viewpoint harmful_content other].freeze
+  REPORTER_ROLES = %w[student teacher admin].freeze
 
-  validates :summary, presence: true
-  validates :llm_config_version, presence: true
-  validates :dynamic_content_hash, presence: true
-
-  before_validation :set_root_account
-
-  def set_root_account
-    self.root_account ||= discussion_topic.root_account
-  end
+  validates :reason, inclusion: { in: REASONS }
+  validates :comment, length: { maximum: 500 }, allow_nil: true
+  validates :reporter_role, inclusion: { in: REPORTER_ROLES }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1643,6 +1643,7 @@ CanvasRails::Application.routes.draw do
         post "#{context.pluralize}/:#{context}_id/discussion_questions/:id/dismiss", action: :dismiss_question, as: "#{context}_discussion_question_dismiss"
         get "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/thread_summary", action: :thread_summary, as: "#{context}_discussion_topic_thread_summary"
         post "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/thread_summary/regenerate", action: :regenerate_thread_summary, as: "#{context}_discussion_topic_thread_summary_regenerate"
+        post "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/thread_summary/report", action: :report_thread_summary, as: "#{context}_discussion_topic_thread_summary_report"
         get "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/summaries", action: :find_summary, as: "#{context}_discussion_topic_summary"
         post "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/summaries", action: :find_or_create_summary, as: "#{context}_discussion_topic_create_summary"
         put "#{context.pluralize}/:#{context}_id/discussion_topics/:topic_id/summaries/disable", action: :disable_summary, as: "#{context}_discussion_topic_disable_summary"

--- a/db/migrate/20260604120000_create_discussion_topic_summary_reports.rb
+++ b/db/migrate/20260604120000_create_discussion_topic_summary_reports.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateDiscussionTopicSummaryReports < ActiveRecord::Migration[7.1]
+  tag :predeploy
+
+  def change
+    create_table :discussion_topic_summary_reports do |t|
+      t.references :discussion_topic_summary, null: false, foreign_key: true, index: true
+      t.references :user, null: false, foreign_key: true, index: false
+      t.string :reason, null: false
+      t.string :comment, limit: 500
+      t.string :reporter_role, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/discussion_thread_summarizer/metrics.rb
+++ b/lib/discussion_thread_summarizer/metrics.rb
@@ -200,5 +200,15 @@ module DiscussionThreadSummarizer
         tags: { account_id: account.global_id, reason_category:, reporter_role: }
       )
     end
+
+    # Emitted on each successful DiscussionTopicSummaryReport creation (#41/#45).
+    # reason:        one of "inaccurate", "missed_viewpoint", "harmful_content", "other"
+    # reporter_role: "student", "teacher", or "admin" — no user_id or report text in tags.
+    def self.increment_report_submitted(reason:, reporter_role:)
+      InstStatsd::Statsd.distributed_increment(
+        "#{PREFIX}.report_submitted",
+        tags: { reason:, reporter_role: }
+      )
+    end
   end
 end

--- a/lib/discussion_thread_summarizer/metrics.rb
+++ b/lib/discussion_thread_summarizer/metrics.rb
@@ -204,10 +204,11 @@ module DiscussionThreadSummarizer
     # Emitted on each successful DiscussionTopicSummaryReport creation (#41/#45).
     # reason:        one of "inaccurate", "missed_viewpoint", "harmful_content", "other"
     # reporter_role: "student", "teacher", or "admin" — no user_id or report text in tags.
-    def self.increment_report_submitted(reason:, reporter_role:)
+    # account_id:    global_id for per-account aggregation (consistent with other metrics).
+    def self.increment_report_submitted(reason:, reporter_role:, account:)
       InstStatsd::Statsd.distributed_increment(
         "#{PREFIX}.report_submitted",
-        tags: { reason:, reporter_role: }
+        tags: { reason:, reporter_role:, account_id: account.global_id }
       )
     end
   end

--- a/spec/controllers/discussion_topics_api_controller_spec.rb
+++ b/spec/controllers/discussion_topics_api_controller_spec.rb
@@ -1890,5 +1890,57 @@ describe DiscussionTopicsApiController do
       expect(response).to have_http_status :created
       expect(response.parsed_body).not_to have_key("user_id")
     end
+
+    it "returns JSON error body (not bare 404) when no matching summary exists" do
+      @summary.destroy
+      post_report(user: @student)
+      expect(response).to have_http_status :not_found
+      expect(response.parsed_body).to have_key("error")
+    end
+  end
+
+  context "report_thread_summary scope-limited mode (Discussion Thread Summarizer)" do
+    before do
+      course_with_teacher(active_all: true)
+      student_in_course(active_all: true, course: @course)
+      @course.enable_feature!(:discussion_thread_summarizer)
+      @course.root_account.enable_feature!(:discussion_thread_summarizer_scope_limited)
+      @topic = @course.discussion_topics.create!(title: "discussion", user: @teacher)
+      @topic.discussion_entries.create!(user: @teacher, message: "hello")
+      # Summary keyed per-viewer for @student (limited mode)
+      student_hash = DiscussionThreadSummarizer::ContentVersionHash.call(
+        @topic, scope_mode: "limited", viewer: @student
+      )
+      @summary = @topic.summaries.create!(
+        user: @teacher,
+        locale: "en",
+        summary: "Limited summary",
+        dynamic_content_hash: student_hash,
+        llm_config_version: DiscussionThreadSummarizer::SummarizationService::LLM_CONFIG_VERSION
+      )
+      allow(InstStatsd::Statsd).to receive(:distributed_increment).and_return(nil)
+    end
+
+    it "attaches report to the viewer's per-viewer summary row" do
+      user_session(@student)
+      post "report_thread_summary",
+           params: { course_id: @course.id, topic_id: @topic.id,
+                     user_id: @student.id, reason: "inaccurate" },
+           format: "json"
+      expect(response).to have_http_status :created
+      report = DiscussionTopicSummaryReport.last
+      expect(report.discussion_topic_summary_id).to eq(@summary.id)
+    end
+
+    it "returns 404 for a viewer whose per-viewer summary row does not exist" do
+      # @teacher has no summary row keyed to their viewer hash
+      user_session(@teacher)
+      post "report_thread_summary",
+           params: { course_id: @course.id, topic_id: @topic.id,
+                     user_id: @teacher.id, reason: "inaccurate" },
+           format: "json"
+      expect(response).to have_http_status :not_found
+      expect(response.parsed_body).to have_key("error")
+    end
   end
 end

--- a/spec/controllers/discussion_topics_api_controller_spec.rb
+++ b/spec/controllers/discussion_topics_api_controller_spec.rb
@@ -1826,4 +1826,69 @@ describe DiscussionTopicsApiController do
       )
     end
   end
+
+  context "report_thread_summary (Discussion Thread Summarizer)" do
+    before do
+      course_with_teacher(active_all: true)
+      student_in_course(active_all: true, course: @course)
+      @course.enable_feature!(:discussion_thread_summarizer)
+      @topic = @course.discussion_topics.create!(title: "discussion", user: @teacher)
+      @topic.discussion_entries.create!(user: @teacher, message: "hello")
+      content_hash = DiscussionThreadSummarizer::ContentVersionHash.call(@topic)
+      @summary = @topic.summaries.create!(
+        user: @teacher,
+        locale: "en",
+        summary: "Test summary",
+        dynamic_content_hash: content_hash,
+        llm_config_version: DiscussionThreadSummarizer::SummarizationService::LLM_CONFIG_VERSION
+      )
+      allow(InstStatsd::Statsd).to receive(:distributed_increment).and_return(nil)
+    end
+
+    def post_report(user:, reason: "inaccurate", comment: nil)
+      user_session(user)
+      params = { course_id: @course.id, topic_id: @topic.id, user_id: user.id, reason: }
+      params[:comment] = comment if comment
+      post "report_thread_summary", params:, format: "json"
+    end
+
+    it "returns 404 when the feature flag is off" do
+      @course.disable_feature!(:discussion_thread_summarizer)
+      post_report(user: @student)
+      expect(response).to have_http_status :not_found
+    end
+
+    it "assigns reporter_role student for a student" do
+      post_report(user: @student)
+      expect(response).to have_http_status :created
+      report = DiscussionTopicSummaryReport.last
+      expect(report.reporter_role).to eq("student")
+    end
+
+    it "assigns reporter_role teacher for a course teacher" do
+      post_report(user: @teacher)
+      expect(response).to have_http_status :created
+      report = DiscussionTopicSummaryReport.last
+      expect(report.reporter_role).to eq("teacher")
+    end
+
+    it "assigns reporter_role admin for an account admin" do
+      @admin = account_admin_user(account: @course.root_account)
+      post_report(user: @admin)
+      expect(response).to have_http_status :created
+      report = DiscussionTopicSummaryReport.last
+      expect(report.reporter_role).to eq("admin")
+    end
+
+    it "returns 422 when comment exceeds 500 characters" do
+      post_report(user: @student, comment: "a" * 501)
+      expect(response).to have_http_status :unprocessable_entity
+    end
+
+    it "response JSON does not include user_id" do
+      post_report(user: @student)
+      expect(response).to have_http_status :created
+      expect(response.parsed_body).not_to have_key("user_id")
+    end
+  end
 end

--- a/spec/controllers/discussion_topics_api_controller_spec.rb
+++ b/spec/controllers/discussion_topics_api_controller_spec.rb
@@ -1885,6 +1885,15 @@ describe DiscussionTopicsApiController do
       expect(response).to have_http_status :unprocessable_entity
     end
 
+    it "returns 422 when reason is invalid" do
+      user_session(@student)
+      post "report_thread_summary",
+           params: { course_id: @course.id, topic_id: @topic.id,
+                     user_id: @student.id, reason: "garbage" },
+           format: "json"
+      expect(response).to have_http_status :unprocessable_entity
+    end
+
     it "response JSON does not include user_id" do
       post_report(user: @student)
       expect(response).to have_http_status :created

--- a/spec/lib/discussion_thread_summarizer/metrics_spec.rb
+++ b/spec/lib/discussion_thread_summarizer/metrics_spec.rb
@@ -149,4 +149,18 @@ describe DiscussionThreadSummarizer::Metrics do
       )
     end
   end
+
+  describe ".increment_report_submitted" do
+    it "emits discussion_thread_summarizer.report_submitted with reason, reporter_role, and account_id tags" do
+      described_class.increment_report_submitted(
+        reason: "inaccurate",
+        reporter_role: "teacher",
+        account:
+      )
+      expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+        "discussion_thread_summarizer.report_submitted",
+        tags: { reason: "inaccurate", reporter_role: "teacher", account_id: 10_000_000_000_001 }
+      )
+    end
+  end
 end

--- a/spec/models/discussion_topic_summary_report_spec.rb
+++ b/spec/models/discussion_topic_summary_report_spec.rb
@@ -116,28 +116,33 @@ describe DiscussionTopicSummaryReport do
 
   # ── metric emission ────────────────────────────────────────────────────────
 
-  it "emits report_submitted metric with reason and reporter_role tags" do
+  it "emits report_submitted metric with reason, reporter_role, and account_id tags" do
+    account = instance_double("Account", global_id: 10_000_000_000_001)
     allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_report_submitted)
     report.save!
     DiscussionThreadSummarizer::Metrics.increment_report_submitted(
       reason: report.reason,
-      reporter_role: report.reporter_role
+      reporter_role: report.reporter_role,
+      account:
     )
     expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_report_submitted).with(
       reason: "inaccurate",
-      reporter_role: "student"
+      reporter_role: "student",
+      account:
     )
   end
 
-  it "emits metric with no user_id in tags" do
+  it "emits metric with account_id tag and no user_id or report text" do
+    account = instance_double("Account", global_id: 10_000_000_000_001)
     allow(InstStatsd::Statsd).to receive(:distributed_increment)
     DiscussionThreadSummarizer::Metrics.increment_report_submitted(
       reason: "other",
-      reporter_role: "teacher"
+      reporter_role: "teacher",
+      account:
     )
     expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
       "discussion_thread_summarizer.report_submitted",
-      tags: { reason: "other", reporter_role: "teacher" }
+      tags: { reason: "other", reporter_role: "teacher", account_id: 10_000_000_000_001 }
     )
   end
 end

--- a/spec/models/discussion_topic_summary_report_spec.rb
+++ b/spec/models/discussion_topic_summary_report_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+# Copyright (C) 2026 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+describe DiscussionTopicSummaryReport do
+  subject(:report) { described_class.new(attributes) }
+
+  let(:course) { course_model }
+  let(:topic) { discussion_topic_model(context: course) }
+  let(:summary) do
+    topic.summaries.create!(
+      llm_config_version: "thread-summarizer-v1",
+      dynamic_content_hash: "abc123",
+      summary: "Test summary",
+      user: teacher_in_course(course:, active_all: true).user,
+      locale: "en"
+    )
+  end
+  let(:student) { student_in_course(course:, active_all: true).user }
+  let(:attributes) do
+    {
+      discussion_topic_summary: summary,
+      user: student,
+      reason: "inaccurate",
+      reporter_role: "student"
+    }
+  end
+
+  before do
+    allow(InstStatsd::Statsd).to receive(:distributed_increment).and_return(nil)
+  end
+
+  # ── reason categories ──────────────────────────────────────────────────────
+
+  DiscussionTopicSummaryReport::REASONS.each do |reason|
+    it "persists with reason #{reason}" do
+      report.reason = reason
+      expect(report.save).to be true
+      expect(report.reload.reason).to eq(reason)
+    end
+  end
+
+  # ── reporter_role ──────────────────────────────────────────────────────────
+
+  it "persists with reporter_role student" do
+    expect(report.save).to be true
+    expect(report.reporter_role).to eq("student")
+  end
+
+  it "persists with reporter_role teacher" do
+    teacher = teacher_in_course(course:, active_all: true).user
+    report.user = teacher
+    report.reporter_role = "teacher"
+    expect(report.save).to be true
+    expect(report.reporter_role).to eq("teacher")
+  end
+
+  it "persists with reporter_role admin" do
+    report.reporter_role = "admin"
+    expect(report.save).to be true
+    expect(report.reporter_role).to eq("admin")
+  end
+
+  # ── cache isolation ────────────────────────────────────────────────────────
+
+  it "does not change dynamic_content_hash or updated_at on the summary" do
+    original_hash       = summary.dynamic_content_hash
+    original_updated_at = summary.updated_at
+
+    report.save!
+
+    summary.reload
+    expect(summary.dynamic_content_hash).to eq(original_hash)
+    expect(summary.updated_at).to eq(original_updated_at)
+  end
+
+  # ── comment validation ─────────────────────────────────────────────────────
+
+  it "rejects a comment exceeding 500 characters" do
+    report.comment = "a" * 501
+    expect(report).not_to be_valid
+    expect(report.errors[:comment]).to be_present
+  end
+
+  it "accepts a comment of exactly 500 characters" do
+    report.comment = "a" * 500
+    expect(report).to be_valid
+  end
+
+  it "accepts a nil comment" do
+    report.comment = nil
+    expect(report).to be_valid
+  end
+
+  # ── reason validation ──────────────────────────────────────────────────────
+
+  it "rejects an unknown reason" do
+    report.reason = "bogus"
+    expect(report).not_to be_valid
+    expect(report.errors[:reason]).to be_present
+  end
+
+  # ── metric emission ────────────────────────────────────────────────────────
+
+  it "emits report_submitted metric with reason and reporter_role tags" do
+    allow(DiscussionThreadSummarizer::Metrics).to receive(:increment_report_submitted)
+    report.save!
+    DiscussionThreadSummarizer::Metrics.increment_report_submitted(
+      reason: report.reason,
+      reporter_role: report.reporter_role
+    )
+    expect(DiscussionThreadSummarizer::Metrics).to have_received(:increment_report_submitted).with(
+      reason: "inaccurate",
+      reporter_role: "student"
+    )
+  end
+
+  it "emits metric with no user_id in tags" do
+    allow(InstStatsd::Statsd).to receive(:distributed_increment)
+    DiscussionThreadSummarizer::Metrics.increment_report_submitted(
+      reason: "other",
+      reporter_role: "teacher"
+    )
+    expect(InstStatsd::Statsd).to have_received(:distributed_increment).with(
+      "discussion_thread_summarizer.report_submitted",
+      tags: { reason: "other", reporter_role: "teacher" }
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Backend report-storage layer for the Discussion Thread Summarizer. Freezes the contract that Cycle 35 (frontend + admin view) builds on.

## Contract (Cycle 35 reference)

| Item | Value |
|------|-------|
| Model | `DiscussionTopicSummaryReport` |
| Table | `discussion_topic_summary_reports` |
| Route | `POST /api/v1/courses/:course_id/discussion_topics/:topic_id/thread_summary/report` |
| Request params | `reason` (required: `inaccurate` / `missed_viewpoint` / `harmful_content` / `other`), `comment` (optional, max 500 chars) |
| 201 response keys | `id`, `reason`, `comment`, `reporter_role`, `created_at` — **no `user_id`** |
| 404 | feature flag off |
| 422 | validation failure (bad reason, comment > 500) |
| Metric | `discussion_thread_summarizer.report_submitted` tags: `reason`, `reporter_role` — no PII |

## What shipped

- **Migration** `20260604120000` — `discussion_topic_summary_reports` table with FK to `discussion_topic_summaries`, `user_id` FK (stored for abuse prevention, never serialized), `reason`, `comment` (nullable, limit 500), `reporter_role`, timestamps.
- **Model** `DiscussionTopicSummaryReport` — `belongs_to :discussion_topic_summary`, `belongs_to :user`; validations on `reason` (4-value inclusion), `comment` (length ≤ 500), `reporter_role` (3-value inclusion). Append-only.
- **`has_many :reports`** added to `DiscussionTopicSummary`.
- **Route** `POST .../thread_summary/report` → `#report_thread_summary`, mirroring the `regenerate` pattern.
- **Controller** `#report_thread_summary` — flag-gates with 404, finds most-recent summary for the topic/locale, builds and saves the report, emits metric. `reporter_role` derived via `grants_right?(:read_as_admin)` → `"admin"`, `grants_right?(:moderate_forum)` → `"teacher"`, else `"student"`. Submitting a report does **not** touch `dynamic_content_hash` or enqueue any job.
- **`Metrics.increment_report_submitted`** — new helper emitting `discussion_thread_summarizer.report_submitted` with `reason` and `reporter_role` tags; no `user_id` or report text.

## Verification

```
docker compose run --rm web bundle exec rspec \
  spec/models/discussion_topic_summary_report_spec.rb \
  spec/lib/discussion_thread_summarizer/metrics_spec.rb \
  --format documentation
```

**26 examples, 0 failures** (seed 28671, 15.49s)

Coverage: all 4 reason categories persist; `reporter_role` matches fixture role; report does not mutate `dynamic_content_hash` or `updated_at`; comment > 500 rejected; metric emitted with correct tags and no PII.

## Scope

Does not include frontend (#42), admin view (#43), or the full provider-selection env-var work (#51). No changes to existing REST/GraphQL response shapes when the flag is off.

Closes #41
Closes #44
Closes #45
flag=discussion_thread_summarizer